### PR TITLE
Update shared-release-major-minor-patch.yaml

### DIFF
--- a/.github/workflows/shared-release-major-minor-patch.yaml
+++ b/.github/workflows/shared-release-major-minor-patch.yaml
@@ -7,6 +7,11 @@ on:
         default: true
         required: false
         type: boolean
+      publish_to_maven:
+        description: 'True to publish the artifacts to maven repository, false to skip the step'
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   release:
@@ -68,7 +73,8 @@ jobs:
           message: 'release-${{ steps.check_version.outputs.version }}'
           tag: '${{ steps.check_version.outputs.version }}'
 
-      - name: Publish 
+      - name: Publish
+        if: ${{ inputs.upload_to_maven }}
         run: mvn -B -Drepo.id=ossrh -Drepo.login=uidadmin -Drepo.pwd="${{ secrets.SONATYPE_REPO_PASSWORD }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" clean deploy
 
       - name: 'Bump Version for Major/Minor'


### PR DESCRIPTION
Adding a parameter so uid2-core, uid2-operator and uid2-optout can share the same versioning helper without polluting sonatype repo.