### PR TITLE
Update docker pipeline to force a release not to be created.

### DIFF
--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -65,7 +65,7 @@ jobs:
               ISRELEASE=false
             fi
             echo "Setting IS_RELEASE to $ISRELEASE"
-            echo "IS_RELEASE=$($ISRELEASE)" >> $GITHUB_OUTPUT
+            echo "IS_RELEASE=$ISRELEASE" >> $GITHUB_OUTPUT
 
       - name: Show Context
         run: |

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -24,9 +24,9 @@ on:
         type: string
         default: ''
       force_release:
-        description: If true, will create a release, if false will not create a release. Empty will use release_type to determine if a release should be created.
+        description: If 'yes', will force the creation a release, if 'no' will not create a release. 'branch' will use release_type and the branch to determine if a release should be created.
         type: string
-        default: ''
+        default: 'branch'
     outputs:
       version_number_output:
         description: The complete version number 
@@ -37,7 +37,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # if force_release = '', check the release type and branch; if force_release = 'true', always create a release; if force_release = 'false', never create a release 
 jobs:
   buildImage:
     runs-on: ubuntu-latest

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   release:
-    name: ${{ github.env.IS_RELEASE == true && 'Is release' || 'Is not release' }}
+    name: ${{ github.env.IS_RELEASE && 'Create release' || 'Publish docker image' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -182,7 +182,7 @@ jobs:
 
       - name: Build Changelog
         id: github_release
-        if: ${{ env.IS_RELEASE == 'true' }}
+        if: ${{ github.env.IS_RELEASE }}
         uses: mikepenz/release-changelog-builder-action@v3
         with:
           configurationJson: |
@@ -194,7 +194,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        if: ${{ env.IS_RELEASE == 'true' }}
+        if: ${{ github.env.IS_RELEASE }}
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ steps.version.outputs.new_version }}

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -64,6 +64,7 @@ jobs:
             else
               ISRELEASE=false
             fi
+            echo "Setting IS_RELEASE to $ISRELEASE"
             echo "IS_RELEASE=$($ISRELEASE)" >> $GITHUB_OUTPUT
 
       - name: Show Context
@@ -73,6 +74,7 @@ jobs:
         shell: bash
         env: 
             GITHUB_CONTEXT: ${{ toJson(github) }}
+            IS_RELEASE: ${{ steps.checkRelease.outputs.IS_RELEASE }}
 
       - name: Check branch and release type
         uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.0.0-pre
@@ -195,7 +197,7 @@ jobs:
 
       - name: Build Changelog
         id: github_release
-        if: ${{ steps.checkRelease.outputs.IS_RELEASE }}
+        if: ${{ steps.checkRelease.outputs.IS_RELEASE == 'true' }}
         uses: mikepenz/release-changelog-builder-action@v3
         with:
           configurationJson: |
@@ -207,7 +209,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        if: ${{ steps.checkRelease.outputs.IS_RELEASE }}
+        if: ${{ steps.checkRelease.outputs.IS_RELEASE == 'true' }}
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ steps.version.outputs.new_version }}

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -24,7 +24,7 @@ on:
         type: string
         default: ''
       force_release:
-        description: If true, will create a release. Only used for testing.
+        description: If true, will create a release, if false will not create a release. Empty will use release_type to determine if a release should be created.
         type: string
         default: ''
     outputs:
@@ -37,11 +37,13 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  IS_RELEASE: ${{ ((inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name )) || inputs.force_release == 'true' }}
+  # if force_release = '', check the release type and branch; if force_release = 'true', always create a release; if force_release = 'false', never create a release 
+  # in this case, the first && is the GitHub ternary operator. Most languages would use a ? instead
+  IS_RELEASE: ${{ inputs.force_release == '' && ((inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name )) || ((inputs.force_release == 'true') || (inputs.force_release == 'false')) }}
 
 jobs:
   release:
-    name: ${{ (((inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name )) || inputs.force_release == 'true') && 'Create Release' || 'Publish Pre-release' }}
+    name: ${{ github.env.IS_RELEASE == true && 'Is release' || 'Is not release' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -121,7 +121,16 @@ jobs:
           echo "git_commit=$(git show --format="%h" --no-patch)" >> $GITHUB_OUTPUT
 
       - name: Commit pom.xml and version.json
-        if: ${{ inputs.version_number_input == '' }}
+        if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.IS_RELEASE != 'true' }} 
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'pom.xml version.json'
+          author_name: Release Workflow
+          author_email: unifiedid-admin+release@thetradedesk.com
+          message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
+
+      - name: Commit pom.xml, version.json and set tag
+        if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.IS_RELEASE == 'true' }} 
         uses: EndBug/add-and-commit@v9
         with:
           add: 'pom.xml version.json'

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -30,8 +30,10 @@ on:
     outputs:
       version_number_output:
         description: The complete version number 
-        value: ${{ jobs.build-publish-docker.outputs.jar_version }}
-      
+        value: ${{ jobs.release.outputs.jar_version }}
+      image_tag:
+        description: The tag used to describe the image in docker
+        value: ${{ jobs.release.outputs.image_tag }}
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -47,6 +49,7 @@ jobs:
       packages: write
     outputs:
       jar_version: ${{ steps.version.outputs.new_version }}
+      image_tag: ${{ steps.updatePom.outputs.image_tag }}
     steps:
       - name: Show Context
         run: |
@@ -85,11 +88,13 @@ jobs:
           branch_name: ${{ github.ref }}
 
       - name: Update pom.xml
+        id: updatePom
         run: |
           current_version=$(grep -o '<version>.*</version>' pom.xml | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
           new_version=${{ steps.version.outputs.new_version }} 
           sed -i "0,/$current_version/s/$current_version/$new_version/" pom.xml
           echo "Version number updated from $current_version to $new_version"
+          echo "image_tag=${{ steps.version.outputs.new_version }}-${{ inputs.cloud_provider }}" >> $GITHUB_OUTPUT
 
       - name: Package JAR
         id: package
@@ -121,7 +126,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.version.outputs.new_version }}-${{ inputs.cloud_provider }}
+            type=raw,value=${{ steps.updatePom.outputs.image_tag }}
 
       - name: Build and export to Docker
         uses: docker/build-push-action@v5

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -30,16 +30,16 @@ on:
     outputs:
       version_number_output:
         description: The complete version number 
-        value: ${{ jobs.release.outputs.jar_version }}
+        value: ${{ jobs.buildImage.outputs.jar_version }}
       image_tag:
         description: The tag used to describe the image in docker
-        value: ${{ jobs.release.outputs.image_tag }}
+        value: ${{ jobs.buildImage.outputs.image_tag }}
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   # if force_release = '', check the release type and branch; if force_release = 'true', always create a release; if force_release = 'false', never create a release 
 jobs:
-  release:
+  buildImage:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -56,14 +56,14 @@ jobs:
             FORCE_NOT_RELEASE=${{ inputs.force_release == 'not' }}
             CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
             BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name) }}
-            if $FORCE_RELEASE then
-              $ISRELEASE=true
-            elif $FORCE_NOT_RELEASE then
-              $ISRELEASE=false
-            elif ($CHECK_BRANCH_FOR_RELEASE) && ($BRANCH_ALLOWS_RELEASE) then
-              $ISRELEASE=true
+            if $FORCE_RELEASE; then
+              ISRELEASE=true
+            elif $FORCE_NOT_RELEASE; then
+              ISRELEASE=false
+            elif ($CHECK_BRANCH_FOR_RELEASE) && ($BRANCH_ALLOWS_RELEASE); then
+              ISRELEASE=true
             else
-              $ISRELEASE=false
+              ISRELEASE=false
             fi
             echo "IS_RELEASE=$($ISRELEASE)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -185,7 +185,7 @@ jobs:
         with:
           configurationJson: |
             {
-              "template": "#{{CHANGELOG}}\n## Installation\n```\ndocker pull ${{ steps.meta.outputs.tags }}\n```\n\n## Changelog\n#{{UNCATEGORIZED}}",
+              "template": "#{{CHANGELOG}}\n## Installation\n```\ndocker pull ${{ steps.meta.outputs.tags }}\n```\n\n## Image reference to deploy: \n```\n${{ steps.updatePom.outputs.image_tag }}\n```\n\n## Changelog\n#{{UNCATEGORIZED}}",
               "pr_template": " - #{{TITLE}} - ( PR: ##{{NUMBER}} )"
             }
         env:

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -39,7 +39,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   # if force_release = '', check the release type and branch; if force_release = 'true', always create a release; if force_release = 'false', never create a release 
   # in this case, the first && is the GitHub ternary operator. Most languages would use a ? instead
-  IS_RELEASE: ${{ inputs.force_release == '' && ((inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name )) || ((inputs.force_release == 'true') || (inputs.force_release == 'false')) }}
+  IS_RELEASE: ${{ inputs.force_release == 'branch' && ((inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name )) || ((inputs.force_release == 'yes') || (inputs.force_release == 'no')) }}
 
 jobs:
   release:

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -38,12 +38,8 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   # if force_release = '', check the release type and branch; if force_release = 'true', always create a release; if force_release = 'false', never create a release 
-  # in this case, the first && is the GitHub ternary operator. Most languages would use a ? instead
-  IS_RELEASE: ${{ inputs.force_release == 'branch' && ((inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name )) || ((inputs.force_release == 'yes') || (inputs.force_release == 'no')) }}
-
 jobs:
   release:
-    name: ${{ github.env.IS_RELEASE && 'Create release' || 'Publish docker image' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -53,6 +49,24 @@ jobs:
       jar_version: ${{ steps.version.outputs.new_version }}
       image_tag: ${{ steps.updatePom.outputs.image_tag }}
     steps:
+      - name: Check if Release
+        id: checkRelease
+        run: |
+            FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
+            FORCE_NOT_RELEASE=${{ inputs.force_release == 'not' }}
+            CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
+            BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name) }}
+            if $FORCE_RELEASE then
+              $ISRELEASE=true
+            elif $FORCE_NOT_RELEASE then
+              $ISRELEASE=false
+            elif ($CHECK_BRANCH_FOR_RELEASE) && ($BRANCH_ALLOWS_RELEASE) then
+              $ISRELEASE=true
+            else
+              $ISRELEASE=false
+            fi
+            echo "IS_RELEASE=$($ISRELEASE)" >> $GITHUB_OUTPUT
+
       - name: Show Context
         run: |
           printenv
@@ -182,7 +196,7 @@ jobs:
 
       - name: Build Changelog
         id: github_release
-        if: ${{ github.env.IS_RELEASE }}
+        if: ${{ steps.checkRelease.outputs.IS_RELEASE }}
         uses: mikepenz/release-changelog-builder-action@v3
         with:
           configurationJson: |
@@ -194,7 +208,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        if: ${{ github.env.IS_RELEASE }}
+        if: ${{ steps.checkRelease.outputs.IS_RELEASE }}
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ steps.version.outputs.new_version }}


### PR DESCRIPTION
Will also output the Image tags.
The component build from Operator will not create a release as part of the build for each operator - the parent workflow will create and manage the release.

Tested from Operator with force_release false
Tested from Admin with force_release as the default