### PR TITLE
Get on a tag when given a build number

### DIFF
--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -91,7 +91,16 @@ jobs:
 
       - name: Checkout full history
         uses: actions/checkout@v4
+        if: ${{ inputs.version_number_input == ''}}
         with:
+          # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
+          fetch-depth: 0
+
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        if: ${{ inputs.version_number_input != ''}}
+        with:
+          ref: v${{ inputs.version_number_input }}
           # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
           fetch-depth: 0
 

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -96,7 +96,7 @@ jobs:
           # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
           fetch-depth: 0
 
-      - name: Checkout full history at tag ${{ inputs.version_number_input }}
+      - name: Checkout full history at tag v${{ inputs.version_number_input }}
         uses: actions/checkout@v4
         if: ${{ inputs.version_number_input != ''}}
         with:

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -89,14 +89,14 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
 
-      - name: Checkout full history
+      - name: Checkout full history on Main
         uses: actions/checkout@v4
         if: ${{ inputs.version_number_input == ''}}
         with:
           # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
           fetch-depth: 0
 
-      - name: Checkout full history
+      - name: Checkout full history at tag ${{ inputs.version_number_input }}
         uses: actions/checkout@v4
         if: ${{ inputs.version_number_input != ''}}
         with:


### PR DESCRIPTION
To reduce the likelihood of changes between updating the version number and building, when a version number is given, use that to get the same version of the Operator