### PR TITLE
Add the check for a Release to the shared action

### DIFF
--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -49,25 +49,12 @@ jobs:
       jar_version: ${{ steps.version.outputs.new_version }}
       image_tag: ${{ steps.updatePom.outputs.image_tag }}
     steps:
-      - name: Check if Release
+
+      - name: Check branch and release type
         id: checkRelease
-        run: |
-            FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
-            FORCE_NOT_RELEASE=${{ inputs.force_release == 'not' }}
-            CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
-            BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name) }}
-            if $FORCE_RELEASE; then
-              ISRELEASE=true
-            elif $FORCE_NOT_RELEASE; then
-              ISRELEASE=false
-            elif ($CHECK_BRANCH_FOR_RELEASE) && ($BRANCH_ALLOWS_RELEASE); then
-              ISRELEASE=true
-            else
-              ISRELEASE=false
-            fi
-            echo "Setting IS_RELEASE to $ISRELEASE"
-            echo "IS_RELEASE=$ISRELEASE" >> $GITHUB_OUTPUT
-            echo "NOT_SNAPSHOT=$BRANCH_ALLOWS_RELEASE" >> $GITHUB_OUTPUT
+        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2.2-pre
+        with:
+          release_type: ${{ inputs.release_type }}
 
       - name: Show Context
         run: |
@@ -77,12 +64,7 @@ jobs:
         env: 
             GITHUB_CONTEXT: ${{ toJson(github) }}
             IS_RELEASE: ${{ steps.checkRelease.outputs.IS_RELEASE }}
-
-      - name: Check branch and release type
-        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.1
-        with:
-          release_type: ${{ inputs.release_type }}
-
+  
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -49,7 +49,6 @@ jobs:
       jar_version: ${{ steps.version.outputs.new_version }}
       image_tag: ${{ steps.updatePom.outputs.image_tag }}
     steps:
-
       - name: Check branch and release type
         id: checkRelease
         uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2.2-pre

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Check branch and release type
         id: checkRelease
-        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2.2-pre
+        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2.2
         with:
           release_type: ${{ inputs.release_type }}
 

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -4,10 +4,41 @@ inputs:
   release_type:
     description: The type of version number to return. Must be one of [Snapshot, Patch, Minor or Major]
     required: true
+  force_release:
+    description: If 'yes', will force the creation a release, if 'no' will not create a release. 'branch' will use release_type and the branch to determine if a release should be created.
+    default: 'branch'
+outputs:
+  is_release: 
+    description: True if a release should be created
+    value: ${{ steps.checkRelease.outputs.IS_RELEASE }}
+  not_snapshot:
+    description: True if the release type is not a snapshot or pre-release build
+    value: ${{ steps.checkRelease.outputs.NOT_SNAPSHOT }}
 runs:
   using: "composite" 
 
   steps:
+    - name: Check if Release
+      id: checkRelease
+      shell: bash
+      run: |
+          FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
+          FORCE_NOT_RELEASE=${{ inputs.force_release == 'not' }}
+          CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
+          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name) }}
+          if $FORCE_RELEASE; then
+            ISRELEASE=true
+          elif $FORCE_NOT_RELEASE; then
+            ISRELEASE=false
+          elif ($CHECK_BRANCH_FOR_RELEASE) && ($BRANCH_ALLOWS_RELEASE); then
+            ISRELEASE=true
+          else
+            ISRELEASE=false
+          fi
+          echo "Setting IS_RELEASE to $ISRELEASE"
+          echo "IS_RELEASE=$ISRELEASE" >> $GITHUB_OUTPUT
+          echo "NOT_SNAPSHOT=$BRANCH_ALLOWS_RELEASE" >> $GITHUB_OUTPUT
+
     - name: Fail if Pre-release on Default branch
       if: ${{ inputs.release_type == 'Snapshot' && github.event.repository.default_branch == github.ref_name }}
       uses: actions/github-script@v7

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
           FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
-          FORCE_NOT_RELEASE=${{ inputs.force_release == 'not' }}
+          FORCE_NOT_RELEASE=${{ inputs.force_release == 'no' }}
           CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
           BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name) }}
           if $FORCE_RELEASE; then


### PR DESCRIPTION
The check if a workflow instance should create a release can be reused by adding it to an action.
The check branch and release type action is already called with the release check, so it makes sense to add the functionality to the check_branch_and_release_type action.

This has been tested on a -pre tag. Once merge, a new release will be created.