### PR TITLE
UID2-2861 Update deprecated packages

### DIFF
--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
           path: target/site/jacoco/*
 
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2.4.0
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@kcc-UID2-2861-fix-github-warnings
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: CRITICAL

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
           path: target/site/jacoco/*
 
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@kcc-UID2-2861-fix-github-warnings
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: CRITICAL

--- a/.github/workflows/shared-check-stable-dependency.yaml
+++ b/.github/workflows/shared-check-stable-dependency.yaml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Resolve dependencies
         run: mvn -B dependency:resolve

--- a/.github/workflows/shared-java-publish-versioned-package.yaml
+++ b/.github/workflows/shared-java-publish-versioned-package.yaml
@@ -66,7 +66,7 @@ jobs:
           key: ${{ secrets.GPG_KEY }}
 
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@kcc-UID2-2861-fix-github-warnings
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: CRITICAL

--- a/.github/workflows/shared-java-publish-versioned-package.yaml
+++ b/.github/workflows/shared-java-publish-versioned-package.yaml
@@ -66,7 +66,7 @@ jobs:
           key: ${{ secrets.GPG_KEY }}
 
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2.4.0
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@kcc-UID2-2861-fix-github-warnings
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: CRITICAL

--- a/.github/workflows/shared-publish-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-docker-versioned.yaml
@@ -182,7 +182,7 @@ jobs:
           hide-progress: true
 
       - name: Upload Trivy scan report to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: inputs.publish_vulnerabilities == 'true'
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/shared-publish-image-aws-ecr.yaml
+++ b/.github/workflows/shared-publish-image-aws-ecr.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
         fetch-depth: 0

--- a/.github/workflows/shared-run-e2e-tests.yaml
+++ b/.github/workflows/shared-run-e2e-tests.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Prepare GCP metadata
         id: prepare_gcp_metadata
         if: ${{ inputs.operator_type == 'gcp'}}
-        uses: IABTechLab/uid2-shared-actions/actions/prepare_gcp_metadata@v2
+        uses: IABTechLab/uid2-shared-actions/actions/prepare_gcp_metadata@kcc-UID2-2861-fix-github-warnings
         with:
           operator_image_version: ${{ inputs.operator_image_version }}
           admin_root: ${{ inputs.admin_root }}

--- a/.github/workflows/shared-run-e2e-tests.yaml
+++ b/.github/workflows/shared-run-e2e-tests.yaml
@@ -87,7 +87,7 @@ jobs:
       id-token: write
     steps:
       - name: Log in to the Docker container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/shared-run-e2e-tests.yaml
+++ b/.github/workflows/shared-run-e2e-tests.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Prepare GCP metadata
         id: prepare_gcp_metadata
         if: ${{ inputs.operator_type == 'gcp'}}
-        uses: IABTechLab/uid2-shared-actions/actions/prepare_gcp_metadata@kcc-UID2-2861-fix-github-warnings
+        uses: IABTechLab/uid2-shared-actions/actions/prepare_gcp_metadata@v2
         with:
           operator_image_version: ${{ inputs.operator_image_version }}
           admin_root: ${{ inputs.admin_root }}

--- a/.github/workflows/shared-run-e2e-tests.yaml
+++ b/.github/workflows/shared-run-e2e-tests.yaml
@@ -94,45 +94,45 @@ jobs:
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Checkout full history
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout uid2-core repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.core_branch }}
           repository: IABTechLab/uid2-core
           path: uid2-core
 
       - name: Checkout uid2-optout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.optout_branch }}
           repository: IABTechLab/uid2-optout
           path: uid2-optout
 
       - name: Checkout uid2-admin repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.admin_branch }}
           repository: IABTechLab/uid2-admin
           path: uid2-admin
 
       - name: Checkout uid2-operator repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.operator_branch }}
           repository: IABTechLab/uid2-operator
           path: uid2-operator
 
       - name: Checkout uid2-shared-actions repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: v2
           repository: IABTechLab/uid2-shared-actions
           path: uid2-shared-actions
 
       - name: Checkout uid2-e2e repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: IABTechLab/uid2-e2e
           path: uid2-e2e

--- a/.github/workflows/shared-validate-image.yaml
+++ b/.github/workflows/shared-validate-image.yaml
@@ -106,7 +106,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: inputs.upload_vulnerabilities
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/shared-validate-image.yaml
+++ b/.github/workflows/shared-validate-image.yaml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout full history
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
           fetch-depth: 0

--- a/.github/workflows/shared-validate-image.yaml
+++ b/.github/workflows/shared-validate-image.yaml
@@ -70,7 +70,7 @@ jobs:
           echo "git_commit=$(git show --format="%h" --no-patch)" >> $GITHUB_OUTPUT
 
       - name: Log in to the Docker container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/actions/build_scan_image/action.yaml
+++ b/actions/build_scan_image/action.yaml
@@ -25,7 +25,7 @@ runs:
         echo "git_commit=$(git show --format="%h" --no-patch)" >> $GITHUB_OUTPUT
 
     - name: Log in to the Container registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/actions/build_scan_image/action.yaml
+++ b/actions/build_scan_image/action.yaml
@@ -72,7 +72,7 @@ runs:
         hide-progress: true
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'

--- a/actions/prepare_gcp_metadata/action.yaml
+++ b/actions/prepare_gcp_metadata/action.yaml
@@ -62,7 +62,7 @@ runs:
 
         # Get the digest
         IMAGE_HASH=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE_NAME}:${IMAGE_TAG}" | cut -d'@' -f2)
-        echo "::set-output name=image_hash::${IMAGE_HASH}"
+        echo "image_hash=${IMAGE_HASH}" >> $GITHUB_OUTPUT
 
     - name: Prepare GCP enclave metadata
       id: metadata

--- a/actions/prepare_gcp_metadata/action.yaml
+++ b/actions/prepare_gcp_metadata/action.yaml
@@ -41,7 +41,7 @@ runs:
         access_token_lifetime: 1200s
 
     - name: Set up Cloud SDK
-      uses: 'google-github-actions/setup-gcloud@v1'
+      uses: google-github-actions/setup-gcloud@v2
     
     - name: Log in to the GCP Registry
       uses: docker/login-action@v3

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -85,7 +85,7 @@ runs:
           IMAGE_VERSION=${{ inputs.new_version }}
 
     - name: Vulnerability scan
-      uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v2
+      uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@kcc-UID2-2861-fix-github-warnings
       with:
         publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
         failure_severity: CRITICAL

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -85,7 +85,7 @@ runs:
           IMAGE_VERSION=${{ inputs.new_version }}
 
     - name: Vulnerability scan
-      uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@kcc-UID2-2861-fix-github-warnings
+      uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v2
       with:
         publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
         failure_severity: CRITICAL

--- a/actions/vulnerability_scan/action.yaml
+++ b/actions/vulnerability_scan/action.yaml
@@ -33,7 +33,7 @@ runs:
       hide-progress: true
 
   - name: Upload Trivy scan report to GitHub Security tab
-    uses: github/codeql-action/upload-sarif@v2
+    uses: github/codeql-action/upload-sarif@v3
     if: inputs.publish_vulnerabilities == 'true'
     with:
       sarif_file: 'trivy-results.sarif'

--- a/actions/vulnerability_scan_filesystem/action.yaml
+++ b/actions/vulnerability_scan_filesystem/action.yaml
@@ -29,7 +29,7 @@ runs:
       hide-progress: true
 
   - name: Upload Trivy scan report to GitHub Security tab
-    uses: github/codeql-action/upload-sarif@v2
+    uses: github/codeql-action/upload-sarif@v3
     if: inputs.publish_vulnerabilities == 'true'
     with:
       sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Tested the warnings are gone (except for azure/login@v1):

- for public operator run: https://github.com/IABTechLab/uid2-operator/actions/runs/8044446799
- for azure operator run: https://github.com/IABTechLab/uid2-operator/actions/runs/8044512087
- for gcp operator run: https://github.com/IABTechLab/uid2-operator/actions/runs/8045498388