### PR TITLE
Pass commit tag of merge PR to setup.

### DIFF
--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json and ${{ inputs.working_dir }}/version.json
         if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE != 'true' }} 
         id: commit-without-tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@llp-UID2-3114-pass-commit-tag-to-setup
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
@@ -77,7 +77,7 @@ jobs:
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json, ${{ inputs.working_dir }}/version.json and set tag
         if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE == 'true' }} 
         id: commit-and-tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@llp-UID2-3114-pass-commit-tag-to-setup
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'

--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -23,7 +23,7 @@ on:
         value: ${{ jobs.incrementVersionNumber.outputs.image_tag }}
       git_tag_or_hash:
         description: The git tag or hash (for snapshots) containing the updated version.
-        value: ${{ jobs.incrementVersionNumber.git_tag_or_hash }}
+        value: ${{ jobs.incrementVersionNumber.outputs.git_tag_or_hash }}
 
 jobs:
   incrementVersionNumber:

--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -21,6 +21,9 @@ on:
       image_tag:
         description: The image tag used to extract metadata for Docker
         value: ${{ jobs.incrementVersionNumber.outputs.image_tag }}
+      git_tag_or_hash:
+        description: The git tag or hash (for snapshots) containing the updated version.
+        value: ${{ jibs.incrementVersionNumber.git_tag_or_hash }}
 
 jobs:
   incrementVersionNumber:
@@ -28,6 +31,7 @@ jobs:
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
       image_tag: ${{ steps.updatePackageJson.outputs.image_tag }}
+      git_tag_or_hash: ${{ steps.commit-and-tag.result == 'success' && steps.commit-and-tag.outputs.git_tag_or_hash || steps.commit-without-tag.outputs.git_tag_or_hash }}
     steps:
       - name: Setup
         id: setup
@@ -64,6 +68,7 @@ jobs:
 
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json and ${{ inputs.working_dir }}/version.json
         if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE != 'true' }} 
+        id: commit-without-tag
         uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'
@@ -71,6 +76,7 @@ jobs:
 
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json, ${{ inputs.working_dir }}/version.json and set tag
         if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE == 'true' }} 
+        id: commit-without-tag
         uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'

--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json and ${{ inputs.working_dir }}/version.json
         if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE != 'true' }} 
         id: commit-without-tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@llp-UID2-3114-pass-commit-tag-to-setup
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
@@ -77,7 +77,7 @@ jobs:
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json, ${{ inputs.working_dir }}/version.json and set tag
         if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE == 'true' }} 
         id: commit-and-tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@llp-UID2-3114-pass-commit-tag-to-setup
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'

--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json, ${{ inputs.working_dir }}/version.json and set tag
         if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE == 'true' }} 
-        id: commit-without-tag
+        id: commit-and-tag
         uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'

--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -23,7 +23,7 @@ on:
         value: ${{ jobs.incrementVersionNumber.outputs.image_tag }}
       git_tag_or_hash:
         description: The git tag or hash (for snapshots) containing the updated version.
-        value: ${{ jibs.incrementVersionNumber.git_tag_or_hash }}
+        value: ${{ jobs.incrementVersionNumber.git_tag_or_hash }}
 
 jobs:
   incrementVersionNumber:

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Setup
         id: setup
-        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@b2d7bdcbb47d161f38ec5e9540e72b16ac6b3c80
+        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@llp-UID2-3114-pass-commit-tag-to-setup
         with:
           release_type: ${{ inputs.release_type }}
           git_tag_or_hash: ${{ inputs.git_tag_or_hash }}

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -30,6 +30,10 @@ on:
         description: The docker context
         default: .
         type: string
+      git_tag_or_hash:
+        description: The git tag or hash to checkout. If not provided, the commit that triggered the workflow will be used.
+        default: ''
+        type: string
 jobs:
   buildImage:
     name: Build Image
@@ -46,6 +50,7 @@ jobs:
         with:
           release_type: ${{ inputs.release_type }}
           version_number_input: ${{ inputs.new_version }}
+          git_tag_or_hash: ${{ inputs.git_tag_or_hash }}
 
       - name: Publish to Docker
         id: publishToDocker

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -49,7 +49,6 @@ jobs:
         uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@ff92d3109cfcfb5de8f7346991dbf6205eaf75cc
         with:
           release_type: ${{ inputs.release_type }}
-          version_number_input: ${{ inputs.new_version }}
           git_tag_or_hash: ${{ inputs.git_tag_or_hash }}
 
       - name: Publish to Docker

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Setup
         id: setup
-        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@main
+        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@v2
         with:
           release_type: ${{ inputs.release_type }}
           git_tag_or_hash: ${{ inputs.git_tag_or_hash }}

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Setup
         id: setup
-        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@ff92d3109cfcfb5de8f7346991dbf6205eaf75cc
+        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@b2d7bdcbb47d161f38ec5e9540e72b16ac6b3c80
         with:
           release_type: ${{ inputs.release_type }}
           git_tag_or_hash: ${{ inputs.git_tag_or_hash }}

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -14,14 +14,6 @@ on:
         description: The image tag used to extract metadata for Docker
         required: true
         type: string
-      publish_vulnerabilities:
-        description: If true, will attempt to publish any vulnerabilities to GitHub. Defaults to true. Set to false for private repos.
-        type: string
-        default: 'true'
-      force_release:
-        description: If 'yes', will force the creation a release, if 'no' will not create a release. 'branch' will use release_type and the branch to determine if a release should be created.
-        type: string
-        default: 'branch'
       docker_file:
         description: The Dockerfile used to build and publish Docker image
         type: string

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@v2
         with:
           release_type: ${{ inputs.release_type }}
+          version_number_input: ${{ inputs.new_version }}
 
       - name: Publish to Docker
         id: publishToDocker

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Setup
         id: setup
-        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@v2
+        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@ff92d3109cfcfb5de8f7346991dbf6205eaf75cc
         with:
           release_type: ${{ inputs.release_type }}
           version_number_input: ${{ inputs.new_version }}

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Setup
         id: setup
-        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@llp-UID2-3114-pass-commit-tag-to-setup
+        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@main
         with:
           release_type: ${{ inputs.release_type }}
           git_tag_or_hash: ${{ inputs.git_tag_or_hash }}

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -12,6 +12,10 @@ inputs:
   add:
     description: Comma- or newline-separated list of paths to add
     required: true
+outputs:
+  git_tag_or_hash: 
+    description: The git tag (or hash if no tag provided) of the merge commit
+    value: ${{ inputs.tag && inputs.tag || steps.get-commit-hash.outputs.commit_sha }}
 
 runs:
   using: "composite"
@@ -49,7 +53,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
-        MERGE_PR_STRATEGY: ${{github.ref_protected == true && '--merge' || '--rebase' }}  
+        MERGE_PR_STRATEGY: ${{github.ref_protected == true && '--merge' || '--rebase' }}
     
     - name: Tag commit
       uses: actions/github-script@v7
@@ -68,3 +72,18 @@ runs:
             ref: 'refs/tags/${{ inputs.tag }}',
             sha: pr.merge_commit_sha
           });
+
+    - name: Get commit hash
+      uses: actions/github-script@v7
+      id: get-commit-hash
+      if: ${{ ! inputs.tag }}
+      with:
+        script: |
+          const pr = (await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: ${{ steps.create-pr.outputs.pull-request-number }}
+          })).data;
+          console.log(`Returning commit SHA ${pr.merge_commit_sha}`);
+          core.setOutput('commit_sha', pr.merge_commit_sha);
+   

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -76,7 +76,7 @@ runs:
     - name: Get commit hash
       uses: actions/github-script@v7
       id: get-commit-hash
-      if: ${{ inputs.tag == '' }}
+      if: ${{ ! inputs.tag }}
       with:
         script: |
           const pr = (await github.rest.pulls.get({

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -76,7 +76,7 @@ runs:
     - name: Get commit hash
       uses: actions/github-script@v7
       id: get-commit-hash
-      if: ${{ ! inputs.tag }}
+      if: ${{ inputs.tag == '' }}
       with:
         script: |
           const pr = (await github.rest.pulls.get({

--- a/actions/shared_publish_setup/action.yaml
+++ b/actions/shared_publish_setup/action.yaml
@@ -7,9 +7,6 @@ inputs:
     required: true
   java_version:
     description: The version of Java to use to compile the JAR. Defaults to 11
-  version_number_input:
-    description: If set, this will check out the repo at a specific tag by prepending v to this version number.
-    default: ''
   git_tag_or_hash:
     description: The git tag or hash to checkout. If not provided, the commit that triggered the workflow will be used.
     default: ''

--- a/actions/shared_publish_setup/action.yaml
+++ b/actions/shared_publish_setup/action.yaml
@@ -8,7 +8,7 @@ inputs:
   java_version:
     description: The version of Java to use to compile the JAR. Defaults to 11
   version_number_input:
-    description: If set, the version number will not be incremented and the given number will be used.
+    description: If set, this will check out the repo at a specific tag by prepending v to this version number.
     default: ''
 
 outputs:
@@ -45,7 +45,7 @@ runs:
         distribution: 'temurin'
         java-version: ${{ inputs.java_version }}
 
-    - name: Checkout full history on Main
+    - name: Checkout full history on the commit that triggered the workflow
       uses: actions/checkout@v4
       if: ${{ inputs.version_number_input == ''}}
       with:

--- a/actions/shared_publish_setup/action.yaml
+++ b/actions/shared_publish_setup/action.yaml
@@ -58,7 +58,7 @@ runs:
       uses: actions/checkout@v4
       if: ${{ inputs.git_tag_or_hash != ''}}
       with:
-        ref: v${{ inputs.git_tag_or_hash }}
+        ref: ${{ inputs.git_tag_or_hash }}
         # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
         fetch-depth: 0
 

--- a/actions/shared_publish_setup/action.yaml
+++ b/actions/shared_publish_setup/action.yaml
@@ -10,6 +10,11 @@ inputs:
   version_number_input:
     description: If set, this will check out the repo at a specific tag by prepending v to this version number.
     default: ''
+  git_tag_or_hash:
+    description: The git tag or hash to checkout. If not provided, the commit that triggered the workflow will be used.
+    default: ''
+    type: string
+  
 
 outputs:
   is_release:
@@ -47,16 +52,16 @@ runs:
 
     - name: Checkout full history on the commit that triggered the workflow
       uses: actions/checkout@v4
-      if: ${{ inputs.version_number_input == ''}}
+      if: ${{ inputs.git_tag_or_hash == ''}}
       with:
         # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
         fetch-depth: 0
 
-    - name: Checkout full history at tag v${{ inputs.version_number_input }}
+    - name: Checkout full history at tag ${{ inputs.git_tag_or_hash }}
       uses: actions/checkout@v4
-      if: ${{ inputs.version_number_input != ''}}
+      if: ${{ inputs.git_tag_or_hash != ''}}
       with:
-        ref: v${{ inputs.version_number_input }}
+        ref: v${{ inputs.git_tag_or_hash }}
         # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
         fetch-depth: 0
 


### PR DESCRIPTION
The goal of this change is to allow shared_publish_to_docker_versioned to accept a git tag or commit hash to use, to address the UID2 portal deployment issue described in UID2-3114.

To allow that, the following changes are made:

.github/workflows/shared-increase-version-number.yaml
- Outputs `git_tag_or_hash` which points to the merge commit (that has the updated version).

.github/workflows/shared-publish-to-docker-versioned.yaml
- New input `git_tag_or_hash` which allows the caller to specify a different git ref to use. This is passed to `shared_publish_setup`.

actions/commit_pr_and_merge/action.yaml
- Returns the tag (if used) or the hash of the merge commit (otherwise). Used by `shared-increase-version-number` above.

actions/shared_publish_setup/action.yaml
- New input `git_tag_or_hash` which, if provided, is used as the git ref to check out.

Successful run: https://github.com/IABTechLab/uid2-self-serve-portal/actions/runs/8550448494
Previous package version was 0.19.12-SNAPSHOT: that pipeline run updated it to 0.19.13-SNAPSHOT

Confirmed that checkout got the right hash:
Run actions/checkout@v4
  with:
    ref: 59305109c95310e1dc38dbf24de5ddd101cffcb8

Confirmed that the contents of the package has the right version:
C:\dev> docker run --rm -it --entrypoint=/bin/sh ghcr.io/iabtechlab/uid2-ssportal:0.19.13-SNAPSHOT
/usr/src/app # ls
api-dist             craco.config.js      package-lock.json    src                  tsconfig.local.json
babel.config.js      knexfile.ts          package.json         tsconfig-api.json    version.json
build                node_modules         public               tsconfig.json
/usr/src/app # cat package.json
{
  "name": "uid2-ssportal",
  "version": "0.19.13-SNAPSHOT",
  "license": "Apache-2.0",
  "repository": {
    "type": "git",