### PR TITLE
Build & test tvOS

### DIFF
--- a/.github/workflows/shared-publish-to-ios-version.yaml
+++ b/.github/workflows/shared-publish-to-ios-version.yaml
@@ -64,8 +64,10 @@ jobs:
       - name: Build, Test
         run: | 
           cd ./${{ inputs.working_dir }}
-          xcodebuild -scheme UID2 -sdk iphonesimulator16.2 -destination "OS=16.2,name=iPhone 14"
+          xcodebuild -scheme UID2 -destination "generic/platform=iOS"
           xcodebuild test -scheme UID2Tests -sdk iphonesimulator16.2 -destination "OS=16.2,name=iPhone 14"
+          xcodebuild -scheme UID2 -destination "generic/platform=tvOS"
+          xcodebuild test -scheme UID2Tests -sdk appletvsimulator16.1 -destination "OS=16.1,name=Apple TV"
 
       - name: Commit sdk_properties, version.json and set tag
         uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v2


### PR DESCRIPTION
Depends on https://github.com/IABTechLab/uid2-ios-sdk/pull/23 adds support for tvOS. 

Build and test tvOS in this action. I also updated the ios build command destination to be generic, which should always use the latest, reducing maintenance.