### PR TITLE
Ensure swiftlint is installed for iOS publish action

### DIFF
--- a/.github/workflows/shared-publish-to-ios-version.yaml
+++ b/.github/workflows/shared-publish-to-ios-version.yaml
@@ -52,7 +52,9 @@ jobs:
           working_dir: ${{ inputs.working_dir }}
 
       - name: Lint code
-        run: swiftlint lint --config .swiftlint.yml --reporter github-actions-logging
+        run: |
+          brew install swiftlint
+          swiftlint lint --config .swiftlint.yml --reporter github-actions-logging
 
       - name: Update UID2.Client.ios
         run: |


### PR DESCRIPTION
The iOS Build and Publish workflow is [failing](https://github.com/IABTechLab/uid2-ios-sdk/actions/runs/8923336454/job/24507365898) because this action needs to install `swiftlint`. The `macos-latest` image seems to have recently switched to `macos-14`, which doesn't install `swiftlint` by default.

