### PR TITLE
Update iOS versioning for Cocoapods changes

### DIFF
--- a/.github/workflows/shared-publish-to-ios-version.yaml
+++ b/.github/workflows/shared-publish-to-ios-version.yaml
@@ -58,9 +58,12 @@ jobs:
 
       - name: Update UID2.Client.ios
         run: |
-          current_version=$(grep -o '<string>.*</string>' ${{ inputs.working_dir }}/Sources/UID2/Properties/sdk_properties.plist | head -1 | sed 's/<string>\(.*\)<\/string>/\1/')
+          formatted_current_version=$(grep -o '\d*,\s*\d*,\s*\d*' ${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift | head -1)
+          current_version=$(echo "$formatted_current_version" | sed 's/\(.*\),[[:space:]]*\(.*\),[[:space:]]*\(.*\)/\1.\2.\3/')
           new_version=${{ steps.version.outputs.new_version }} 
-          sed -i '' -e "s/$current_version/$new_version/g" ${{ inputs.working_dir }}/Sources/UID2/Properties/sdk_properties.plist
+          formatted_new_version=$(echo "$new_version" | sed 's/\([[:digit:]]\)\.\([[:digit:]]\)\.\([[:digit:]]\)/\1, \2, \3/')
+          sed -i '' -e "s/$formatted_current_version/$formatted_new_version/g" ${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift
+          sed -i '' -e "s/$current_version/$new_version/g" ${{ inputs.working_dir }}/UID2.podspec.json
           echo "Version number updated from $current_version to $new_version"
 
       - name: Select Xcode 15.3
@@ -72,10 +75,10 @@ jobs:
           xcodebuild -scheme UID2 -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
           xcodebuild test -scheme UID2 -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
 
-      - name: Commit sdk_properties, version.json and set tag
+      - name: Commit SDK properties, podspec, version.json and set tag
         uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v2
         with:
-          add: '${{ inputs.working_dir }}/Sources/UID2/Properties/sdk_properties.plist ${{ inputs.working_dir }}/version.json'
+          add: '${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift ${{ inputs.working_dir }}/UID2.podspec.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
           tag: v${{ steps.version.outputs.new_version }}          
 


### PR DESCRIPTION
Updates required for changes in https://github.com/IABTechLab/uid2-ios-sdk/pull/40 

Version is now specified as a [tuple](https://github.com/IABTechLab/uid2-ios-sdk/blob/ac16a777d47bc48ecbfb477c21a59793dfb0c5ad/Sources/UID2/Properties/UID2SDKProperties.swift#L13) in code, i.e. `(1, 2, 0)` so I have updated the parsing and substitution. Additionally, we need to bump the version contained in `UID2.podspec.json`, which is in the usual `.` separated form.

The final piece of this is an action to publish the CocoaPod. It requires a secret token, which I've registered in this repository's Settings. These tokens expire every 5 months or so. Should we make this step a separate workflow, to run after releasing?

```yml
- name: Publish CocoaPod to trunk
env:
    COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
run: |
    pod spec lint ${{ inputs.working_dir }}/UID2.podspec.json
    pod trunk push ${{ inputs.working_dir }}/UID2.podspec.json

```