### PR TITLE
Update iOS versioning for UID2Prebid podspec

### DIFF
--- a/.github/workflows/shared-publish-to-ios-version.yaml
+++ b/.github/workflows/shared-publish-to-ios-version.yaml
@@ -64,6 +64,7 @@ jobs:
           formatted_new_version=$(echo "$new_version" | sed 's/\([[:digit:]]\)\.\([[:digit:]]\)\.\([[:digit:]]\)/\1, \2, \3/')
           sed -i '' -e "s/$formatted_current_version/$formatted_new_version/g" ${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift
           sed -i '' -e "s/$current_version/$new_version/g" ${{ inputs.working_dir }}/UID2.podspec.json
+          sed -i '' -e "s/$current_version/$new_version/g" ${{ inputs.working_dir }}/UID2Prebid.podspec.json
           echo "Version number updated from $current_version to $new_version"
 
       - name: Select Xcode 15.3
@@ -75,10 +76,10 @@ jobs:
           xcodebuild -scheme UID2 -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
           xcodebuild test -scheme UID2 -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
 
-      - name: Commit SDK properties, podspec, version.json and set tag
+      - name: Commit SDK properties, podspecs, version.json and set tag
         uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v2
         with:
-          add: '${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift ${{ inputs.working_dir }}/UID2.podspec.json ${{ inputs.working_dir }}/version.json'
+          add: '${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift ${{ inputs.working_dir }}/UID2.podspec.json ${{ inputs.working_dir }}/UID2Prebid.podspec.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
           tag: v${{ steps.version.outputs.new_version }}          
 


### PR DESCRIPTION
The iOS SDK repo now contains a second podspec file that we'd like to version the same as `UID2.podspec.json`. Update the job to process `UID2Prebid.podspec.json` too.