### PR TITLE
Check for test failures and errors in java build

### DIFF
--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout uid2-shared-actions repo
         uses: actions/checkout@v4
         with:
-          ref: v3
+          ref: aaq-check-test-failures-java-build
           repository: IABTechLab/uid2-shared-actions
           path: uid2-shared-actions
 

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout uid2-shared-actions repo
         uses: actions/checkout@v4
         with:
-          ref: aaq-check-test-failures-java-build
+          ref: v3
           repository: IABTechLab/uid2-shared-actions
           path: uid2-shared-actions
 

--- a/scripts/compile_java_test_and_verify.sh
+++ b/scripts/compile_java_test_and_verify.sh
@@ -72,12 +72,12 @@ fi
 
 echo "INFO: $tests_run tests were run!"
 
-if [ "$tests_failed" -neq 0 ]; then
+if [ "$tests_failed" -ne 0 ]; then
     echo "ERROR: $tests_failed Tests Failed!"
     exit 1
 fi
 
-if [ "$tests_errors" -neq 0 ]; then
+if [ "$tests_errors" -ne 0 ]; then
     echo "ERROR: $tests_errors Tests had errors!"
     exit 1
 fi

--- a/scripts/compile_java_test_and_verify.sh
+++ b/scripts/compile_java_test_and_verify.sh
@@ -53,9 +53,12 @@ mvn_command+=" clean compile test"
 echo "DEBUG: Executing Maven command: ${mvn_command}"
 ${mvn_command} | tee build.log
 
-tests_run=$(cat build.log  | grep "Tests run:" | tail -n 1 | sed 's/.*Tests run: \([0-9]*\).*/\1/')
+TEST_RESULTS=$(cat build.log  | grep "Tests run:" | tail -n 1)
+tests_run=$(echo $TEST_RESULTS | sed 's/.*Tests run: \([0-9]*\).*/\1/')
+tests_failed=$(echo $TEST_RESULTS | sed 's/.*Failures: \([0-9]*\).*/\1/')
+tests_errors=$(echo $TEST_RESULTS | sed 's/.*Errors: \([0-9]*\).*/\1/')
 
-echo "DEBUG: tests_run = $tests_run"
+echo "DEBUG: tests_run = $tests_run tests_failed = $tests_failed tests_errors = $tests_errors"
 
 if [ -z "$tests_run" ]; then
     echo "WARNING: Could not determine the number of tests run."
@@ -68,3 +71,13 @@ if [ "$tests_run" -eq 0 ]; then
 fi
 
 echo "INFO: $tests_run tests were run!"
+
+if [ "$tests_failed" -neq 0 ]; then
+    echo "ERROR: $tests_failed Tests Failed!"
+    exit 1
+fi
+
+if [ "$tests_errors" -neq 0 ]; then
+    echo "ERROR: $tests_errors Tests had errors!"
+    exit 1
+fi


### PR DESCRIPTION
Sample build which passed but wasn't checking failed tests 
https://github.com/IABTechLab/uid2-operator/actions/runs/13577561151/job/37957166574

Tested these changes in a dummy operator PR with failing tests.
https://github.com/IABTechLab/uid2-operator/actions/runs/13661584024/job/38199464207
Logs:
```
Error:  Tests run: 681, Failures: 0, Errors: 6, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:50 min
[INFO] Finished at: 2025-03-04T21:39:59Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project uid2-operator: There are test failures.
Error:  
Error:  Please refer to /home/runner/work/uid2-operator/uid2-operator/target/surefire-reports for the individual test results.
Error:  Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
DEBUG: tests_run = 681 tests_failed = 0 tests_errors = 6
INFO: 681 tests were run!
ERROR: 6 Tests had errors!
Error: Process completed with exit code 1.
```
