### PR TITLE
Fix error for skip_tests flag for building

### DIFF
--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -7,11 +7,11 @@ on:
         default: '11'
       vulnerability_scan_only:
         description: If true, only the vulnerability scanning step will run.
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
       publish_vulnerabilities:
-        type: string
-        default: 'true'
+        type: boolean
+        default: true
       vulnerability_severity:
         description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised. Must be one of ['CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM'] (without space in between).
         type: string
@@ -41,31 +41,31 @@ jobs:
           path: uid2-shared-actions
 
       - name: Set up JDK
-        if: ${{ inputs.vulnerability_scan_only == 'false' }}
+        if: ${{ inputs.vulnerability_scan_only == false }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
 
       - name: Build and run unit tests
-        if: ${{ inputs.vulnerability_scan_only == 'false' && inputs.skip_tests == false }}
+        if: ${{ inputs.vulnerability_scan_only == false && inputs.skip_tests == false }}
         working-directory: ${{ inputs.working_dir }}
         run: |
           bash uid2-shared-actions/scripts/compile_java_test_and_verify.sh
 
       - name: Build without unit tests
-        if: ${{ inputs.vulnerability_scan_only == 'false'  && inputs.skip_tests == true }}
+        if: ${{ inputs.vulnerability_scan_only == false  && inputs.skip_tests == true }}
         working-directory: ${{ inputs.working_dir }}
         run: |
           mvn -B clean compile -DskipTests
 
       - name: Generate code coverage
-        if: ${{ inputs.vulnerability_scan_only == 'false' }}
+        if: ${{ inputs.vulnerability_scan_only == false }}
         run: mvn jacoco:report
         working-directory: ${{ inputs.working_dir }}
 
       - name: Archive code coverage results
-        if: ${{ inputs.vulnerability_scan_only == 'false' }}
+        if: ${{ inputs.vulnerability_scan_only == false }}
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -7,11 +7,11 @@ on:
         default: '11'
       vulnerability_scan_only:
         description: If true, only the vulnerability scanning step will run.
-        type: boolean
-        default: false
+        type: string
+        default: 'false'
       publish_vulnerabilities:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
       vulnerability_severity:
         description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised. Must be one of ['CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM'] (without space in between).
         type: string
@@ -22,7 +22,7 @@ on:
         default: '.'
       skip_tests:
         description: If true, will skip tests when building and running unit tests. Defaults to false. Set to true for repos without tests.
-        type: boolean
+        type: string
         default: false
 
 jobs:
@@ -41,31 +41,31 @@ jobs:
           path: uid2-shared-actions
 
       - name: Set up JDK
-        if: ${{ inputs.vulnerability_scan_only == false }}
+        if: ${{ inputs.vulnerability_scan_only == 'false' }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
 
       - name: Build and run unit tests
-        if: ${{ inputs.vulnerability_scan_only == false && inputs.skip_tests == false }}
+        if: ${{ inputs.vulnerability_scan_only == 'false' && inputs.skip_tests == 'false' }}
         working-directory: ${{ inputs.working_dir }}
         run: |
           bash uid2-shared-actions/scripts/compile_java_test_and_verify.sh
 
       - name: Build without unit tests
-        if: ${{ inputs.vulnerability_scan_only == false  && inputs.skip_tests == true }}
+        if: ${{ inputs.vulnerability_scan_only == 'false'  && inputs.skip_tests == 'true' }}
         working-directory: ${{ inputs.working_dir }}
         run: |
           mvn -B clean compile -DskipTests
 
       - name: Generate code coverage
-        if: ${{ inputs.vulnerability_scan_only == false }}
+        if: ${{ inputs.vulnerability_scan_only == 'false' }}
         run: mvn jacoco:report
         working-directory: ${{ inputs.working_dir }}
 
       - name: Archive code coverage results
-        if: ${{ inputs.vulnerability_scan_only == false }}
+        if: ${{ inputs.vulnerability_scan_only == 'false' }}
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -48,13 +48,13 @@ jobs:
           java-version: ${{ inputs.java_version }}
 
       - name: Build and run unit tests
-        if: ${{ inputs.vulnerability_scan_only == 'false' && inputs.skip_tests == 'false' }}
+        if: ${{ inputs.vulnerability_scan_only == 'false' && inputs.skip_tests == false }}
         working-directory: ${{ inputs.working_dir }}
         run: |
           bash uid2-shared-actions/scripts/compile_java_test_and_verify.sh
 
       - name: Build without unit tests
-        if: ${{ inputs.vulnerability_scan_only == 'false'  && inputs.skip_tests == 'true' }}
+        if: ${{ inputs.vulnerability_scan_only == 'false'  && inputs.skip_tests == true }}
         working-directory: ${{ inputs.working_dir }}
         run: |
           mvn -B clean compile -DskipTests

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -23,7 +23,7 @@ on:
       skip_tests:
         description: If true, will skip tests when building and running unit tests. Defaults to false. Set to true for repos without tests.
         type: string
-        default: false
+        default: 'false'
 
 jobs:
   build:


### PR DESCRIPTION
Tested in [MR](https://github.com/IABTechLab/uid2-attestation-gcp/pull/26) of uid2-attestation-gcp

When `skip_tests` is not set and use default value as false:
[Build action](https://github.com/IABTechLab/uid2-attestation-gcp/actions/runs/13937858059)
When 'skip-tests` is false:
[Build action](https://github.com/IABTechLab/uid2-attestation-gcp/actions/runs/13937874538)
<img width="511" alt="Screenshot 2025-03-17 at 6 18 34 PM" src="https://github.com/user-attachments/assets/1553217c-047c-4465-a855-92ad831a34d6" />

When `skip_tests` is true:
[Build action](https://github.com/IABTechLab/uid2-attestation-gcp/actions/runs/13937836547/job/39009041993)
<img width="497" alt="Screenshot 2025-03-17 at 6 20 42 PM" src="https://github.com/user-attachments/assets/08bb3ff4-42b1-4596-8e66-3d008155766a" />


