### PR TITLE
xuy-UID2-5055-release-operator-from-releas-branch

### DIFF
--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -25,7 +25,7 @@ runs:
           FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
           FORCE_NOT_RELEASE=${{ inputs.force_release == 'no' }}
           CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
-          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'release')) }}
+          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'priv-op-release')) }}
           if $FORCE_RELEASE; then
             ISRELEASE=true
           elif $FORCE_NOT_RELEASE; then
@@ -47,8 +47,8 @@ runs:
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
     - name: Fail if Release and not on Default branch or release branch
-      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'release')}}
+      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'priv-op-release')}}
       uses: actions/github-script@v7
       with:
           script: |
-            core.setFailed('Releases can not be created on a feature branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
+            core.setFailed('Releases only be created on a main or priv-op-release-yyyy-q? branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -25,7 +25,7 @@ runs:
           FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
           FORCE_NOT_RELEASE=${{ inputs.force_release == 'no' }}
           CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
-          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'private-operator-release')) }}
+          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'priop-release')) }}
           if $FORCE_RELEASE; then
             ISRELEASE=true
           elif $FORCE_NOT_RELEASE; then
@@ -46,9 +46,9 @@ runs:
           script: |
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
-    - name: Fail if Release and not on Default branch or private-operator-release-yyyy-q branch
-      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'private-operator-release')}}
+    - name: Fail if Release and not on Default branch or priop-release-yyyy-q branch
+      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'priop-release')}}
       uses: actions/github-script@v7
       with:
           script: |
-            core.setFailed('Releases can only be created on a Default or private-operator-release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
+            core.setFailed('Releases can only be created on a Default or priop-release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -51,4 +51,4 @@ runs:
       uses: actions/github-script@v7
       with:
           script: |
-            core.setFailed('Releases only be created on a main or priv-op-release-yyyy-q? branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
+            core.setFailed('Releases can only be created on a main or priv-op-release-yyyy-q? branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -46,9 +46,9 @@ runs:
           script: |
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
-    - name: Fail if Release and not on Default branch or release branch
+    - name: Fail if Release and not on Default branch or private-operator-release-yyyy-q branch
       if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'private-operator-release')}}
       uses: actions/github-script@v7
       with:
           script: |
-            core.setFailed('Releases can only be created on a main or private-operator-release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
+            core.setFailed('Releases can only be created on a Default or private-operator-release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -47,7 +47,7 @@ runs:
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
     - name: Fail if Release and not on Default branch or release branch
-      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'release'))}}
+      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'release')}}
       uses: actions/github-script@v7
       with:
           script: |

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -25,7 +25,7 @@ runs:
           FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
           FORCE_NOT_RELEASE=${{ inputs.force_release == 'no' }}
           CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
-          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'priop-release')) }}
+          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'release')) }}
           if $FORCE_RELEASE; then
             ISRELEASE=true
           elif $FORCE_NOT_RELEASE; then
@@ -46,9 +46,9 @@ runs:
           script: |
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
-    - name: Fail if Release and not on Default branch or priop-release-yyyy-q branch
-      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'priop-release')}}
+    - name: Fail if Release and not on Default branch or release-yyyy-q branch
+      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'release')}}
       uses: actions/github-script@v7
       with:
           script: |
-            core.setFailed('Releases can only be created on a Default or priop-release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
+            core.setFailed('Releases can only be created on a Default or release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -25,7 +25,7 @@ runs:
           FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
           FORCE_NOT_RELEASE=${{ inputs.force_release == 'no' }}
           CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
-          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name) }}
+          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'release')) }}
           if $FORCE_RELEASE; then
             ISRELEASE=true
           elif $FORCE_NOT_RELEASE; then

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -25,7 +25,7 @@ runs:
           FORCE_RELEASE=${{ inputs.force_release == 'yes' }}
           FORCE_NOT_RELEASE=${{ inputs.force_release == 'no' }}
           CHECK_BRANCH_FOR_RELEASE=${{ inputs.force_release == 'branch' }}
-          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'priv-op-release')) }}
+          BRANCH_ALLOWS_RELEASE=${{ (inputs.release_type == 'Major' || inputs.release_type == 'Minor' || inputs.release_type == 'Patch') && (github.event.repository.default_branch == github.ref_name || startsWith(github.ref_name, 'private-operator-release')) }}
           if $FORCE_RELEASE; then
             ISRELEASE=true
           elif $FORCE_NOT_RELEASE; then
@@ -47,8 +47,8 @@ runs:
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
     - name: Fail if Release and not on Default branch or release branch
-      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'priv-op-release')}}
+      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'private-operator-release')}}
       uses: actions/github-script@v7
       with:
           script: |
-            core.setFailed('Releases can only be created on a main or priv-op-release-yyyy-q? branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
+            core.setFailed('Releases can only be created on a main or private-operator-release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -46,8 +46,8 @@ runs:
           script: |
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
-    - name: Fail if Release and not on Default branch
-      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name }}
+    - name: Fail if Release and not on Default branch or release branch
+      if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'release'))}}
       uses: actions/github-script@v7
       with:
           script: |

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -80,7 +80,7 @@ runs:
           else
             echo "new_version=$NBGV_SimpleVersion-SNAPSHOT" >> $GITHUB_OUTPUT
           fi
-        elif [[ "$BRANCH_NAME" =~ ^release.* ]]; then
+        elif [[ "$BRANCH_NAME" =~ ^private-operator-release.* ]]; then
           BASE_VERSION=$NBGV_SimpleVersion
           RELEASE_NUMBER=$(git rev-list --count HEAD ^$DEFAULT_BRANCH)
           echo "new_version=$BASE_VERSION-r$RELEASE_NUMBER" >> $GITHUB_OUTPUT

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -81,7 +81,7 @@ runs:
           fi
         elif [[ "$BRANCH_NAME" =~ ^release.* ]]; then
           BASE_VERSION=$NBGV_SimpleVersion
-          RELEASE_NUMBER=$GITHUB_RUN_NUMBER
+          RELEASE_NUMBER=$(git rev-list --count HEAD ^$DEFAULT_BRANCH)
           echo "new_version=$BASE_VERSION-r$RELEASE_NUMBER" >> $GITHUB_OUTPUT
         elif [[ "$BRANCH_NAME_TRUNC" != "" && "$BRANCH_NAME_TRUNC" != "master" && "$BRANCH_NAME_TRUNC" != "main" ]]; then
           echo "new_version=$NBGV_SimpleVersion-$BRANCH_NAME_TRUNC" >> $GITHUB_OUTPUT

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -81,9 +81,14 @@ runs:
             echo "new_version=$NBGV_SimpleVersion-SNAPSHOT" >> $GITHUB_OUTPUT
           fi
         elif [[ "$BRANCH_NAME" =~ ^priop-release.* ]]; then
-          BASE_VERSION=$NBGV_SimpleVersion
-          RELEASE_NUMBER=$(git rev-list --count HEAD ^$DEFAULT_BRANCH)
-          echo "new_version=$BASE_VERSION-r$RELEASE_NUMBER" >> $GITHUB_OUTPUT
+          git fetch --tags --all
+          # Find the base tag that the branch derived from
+          BASE_TAG=$(git describe --tags --abbrev=0 $(git merge-base HEAD origin/main))
+          BASE_TAG_CLEAN=$(echo "$BASE_TAG" | sed -E 's/-r[0-9]+$//')
+          # Count number of commits since the clean tag
+          REV_COUNT=$(git rev-list --count ${BASE_TAG_CLEAN}..HEAD)
+          VERSION="${BASE_TAG_CLEAN}-r${REV_COUNT}"
+          echo "new_version=$VERSION" >> $GITHUB_OUTPUT
         elif [[ "$BRANCH_NAME_TRUNC" != "" && "$BRANCH_NAME_TRUNC" != "master" && "$BRANCH_NAME_TRUNC" != "main" ]]; then
           echo "new_version=$NBGV_SimpleVersion-$BRANCH_NAME_TRUNC" >> $GITHUB_OUTPUT
         else

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -80,7 +80,7 @@ runs:
           else
             echo "new_version=$NBGV_SimpleVersion-SNAPSHOT" >> $GITHUB_OUTPUT
           fi
-        elif [[ "$BRANCH_NAME" =~ ^private-operator-release.* ]]; then
+        elif [[ "$BRANCH_NAME" =~ ^priop-release.* ]]; then
           BASE_VERSION=$NBGV_SimpleVersion
           RELEASE_NUMBER=$(git rev-list --count HEAD ^$DEFAULT_BRANCH)
           echo "new_version=$BASE_VERSION-r$RELEASE_NUMBER" >> $GITHUB_OUTPUT

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -66,7 +66,7 @@ runs:
         REF_PREFIX="refs/heads/"
         BRANCH_NAME=${BRANCH_NAME_WITH_REF#$REF_PREFIX}
         BRANCH_NAME_TRUNC=${BRANCH_NAME#50}
-        DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+        DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
         if [[ "${{ inputs.version_number }}" != "" ]]; then
           echo "new_version=${{ inputs.version_number }}" >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.type }}" == "Snapshot" ]]; then

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -66,7 +66,7 @@ runs:
         REF_PREFIX="refs/heads/"
         BRANCH_NAME=${BRANCH_NAME_WITH_REF#$REF_PREFIX}
         BRANCH_NAME_TRUNC=${BRANCH_NAME#50}
-        DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+        DEFAULT_BRANCH="origin/${{ github.event.repository.default_branch }}"
         if [[ "${{ inputs.version_number }}" != "" ]]; then
           echo "new_version=${{ inputs.version_number }}" >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.type }}" == "Snapshot" ]]; then

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -66,7 +66,6 @@ runs:
         REF_PREFIX="refs/heads/"
         BRANCH_NAME=${BRANCH_NAME_WITH_REF#$REF_PREFIX}
         BRANCH_NAME_TRUNC=${BRANCH_NAME#50}
-        DEFAULT_BRANCH="origin/${{ github.event.repository.default_branch }}"
         if [[ "${{ inputs.version_number }}" != "" ]]; then
           echo "new_version=${{ inputs.version_number }}" >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.type }}" == "Snapshot" ]]; then

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -80,7 +80,7 @@ runs:
           else
             echo "new_version=$NBGV_SimpleVersion-SNAPSHOT" >> $GITHUB_OUTPUT
           fi
-        elif [[ "$BRANCH_NAME" =~ ^priop-release.* ]]; then
+        elif [[ "$BRANCH_NAME" =~ ^release.* ]]; then
           git fetch --tags --all
           # Find the base tag that the branch derived from
           BASE_TAG=$(git describe --tags --abbrev=0 $(git merge-base HEAD origin/main))

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -79,13 +79,12 @@ runs:
           else
             echo "new_version=$NBGV_SimpleVersion-SNAPSHOT" >> $GITHUB_OUTPUT
           fi
-        elif [[ "$BRANCH_NAME_TRUNC" != "" && "$BRANCH_NAME_TRUNC" != "master" && "$BRANCH_NAME_TRUNC" != "main" ]]; then
-          echo "new_version=$NBGV_SimpleVersion-$BRANCH_NAME_TRUNC" >> $GITHUB_OUTPUT
         elif [[ "$BRANCH_NAME" =~ ^release.* ]]; then
-        # For release branches, append -r with incrementing number
           BASE_VERSION=$NBGV_SimpleVersion
           RELEASE_NUMBER=$GITHUB_RUN_NUMBER
           echo "new_version=$BASE_VERSION-r$RELEASE_NUMBER" >> $GITHUB_OUTPUT
+        elif [[ "$BRANCH_NAME_TRUNC" != "" && "$BRANCH_NAME_TRUNC" != "master" && "$BRANCH_NAME_TRUNC" != "main" ]]; then
+          echo "new_version=$NBGV_SimpleVersion-$BRANCH_NAME_TRUNC" >> $GITHUB_OUTPUT
         else
           echo "new_version=$NBGV_SimpleVersion" >> $GITHUB_OUTPUT
         fi

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -87,7 +87,7 @@ runs:
           BASE_TAG_CLEAN=$(echo "$BASE_TAG" | sed -E 's/-r[0-9]+$//')
           # Count number of commits since the clean tag
           REV_COUNT=$(git rev-list --count ${BASE_TAG_CLEAN}..HEAD)
-          VERSION="${BASE_TAG_CLEAN}-r${REV_COUNT}"
+          VERSION="$(echo "$BASE_TAG_CLEAN" | sed -E 's/^v//')-r${REV_COUNT}"
           echo "new_version=$VERSION" >> $GITHUB_OUTPUT
         elif [[ "$BRANCH_NAME_TRUNC" != "" && "$BRANCH_NAME_TRUNC" != "master" && "$BRANCH_NAME_TRUNC" != "main" ]]; then
           echo "new_version=$NBGV_SimpleVersion-$BRANCH_NAME_TRUNC" >> $GITHUB_OUTPUT

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -66,6 +66,7 @@ runs:
         REF_PREFIX="refs/heads/"
         BRANCH_NAME=${BRANCH_NAME_WITH_REF#$REF_PREFIX}
         BRANCH_NAME_TRUNC=${BRANCH_NAME#50}
+        DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
         if [[ "${{ inputs.version_number }}" != "" ]]; then
           echo "new_version=${{ inputs.version_number }}" >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.type }}" == "Snapshot" ]]; then

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -81,6 +81,11 @@ runs:
           fi
         elif [[ "$BRANCH_NAME_TRUNC" != "" && "$BRANCH_NAME_TRUNC" != "master" && "$BRANCH_NAME_TRUNC" != "main" ]]; then
           echo "new_version=$NBGV_SimpleVersion-$BRANCH_NAME_TRUNC" >> $GITHUB_OUTPUT
+        elif [[ "$BRANCH_NAME" =~ ^release.* ]]; then
+        # For release branches, append -r with incrementing number
+          BASE_VERSION=$NBGV_SimpleVersion
+          RELEASE_NUMBER=$GITHUB_RUN_NUMBER
+          echo "new_version=$BASE_VERSION-r$RELEASE_NUMBER" >> $GITHUB_OUTPUT
         else
           echo "new_version=$NBGV_SimpleVersion" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
Proposal : https://thetradedesk.atlassian.net/wiki/spaces/UID2/pages/420814210/Proposal+for+private+operator+release+steps

Summary of Changes:

Enabled building releases from release branches.

Release versions will follow the format base-rN (e.g., 5.49.6-r2).

Release version updates will be merged into the release branch only, without impacting the main branch version (as intended).

✅ Tested at: [GitHub Actions Run](https://github.com/IABTechLab/uid2-operator/actions/runs/14050794370/job/39340687862) - a version has generated as 5.50.5-r4.

🛡️ This logic only applies to release branches and will not affect existing GitHub Actions.