### PR TITLE
UID2-6837: Replace GHCR_PAT with GITHUB_TOKEN in E2E workflow

### DIFF
--- a/.github/workflows/shared-run-e2e-tests.yaml
+++ b/.github/workflows/shared-run-e2e-tests.yaml
@@ -115,7 +115,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout full history
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Replace `secrets.GHCR_PAT` with `secrets.GITHUB_TOKEN` in `shared-run-e2e-tests.yaml`
- `GHCR_PAT` was deleted (see UID2-6815). `GITHUB_TOKEN` is automatically available and the job already has `packages: read` permission.
- This is the only workflow in uid2-shared-actions that referenced `GHCR_PAT`.

## Test plan
- [ ] Re-run a release workflow that triggers E2E tests (e.g. uid2-optout) and verify the Docker login step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)