### PR TITLE
Pin actions to commit SHAs in shared-build-and-test and vulnerability_scan

### DIFF
--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Checkout uid2-shared-actions repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: v3
           repository: IABTechLab/uid2-shared-actions
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set up JDK
         if: ${{ inputs.vulnerability_scan_only == 'false' }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
@@ -66,13 +66,13 @@ jobs:
 
       - name: Archive code coverage results
         if: ${{ inputs.vulnerability_scan_only == 'false' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: code-coverage-report
           path: ${{ inputs.working_dir }}/target/site/jacoco/*
 
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@aa84a60f4774fd78427d3882418dd913588abd8d # v3
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: ${{ inputs.vulnerability_severity }}

--- a/actions/vulnerability_scan/action.yaml
+++ b/actions/vulnerability_scan/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
   - name: Checkout repo
-    uses: actions/checkout@v4
+    uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     with:
       repository: IABTechLab/uid2-shared-actions
       ref: v3
@@ -39,7 +39,7 @@ runs:
       rm -rf tmp-vulnerability-scan
 
   - name: Setup oras
-    uses: oras-project/setup-oras@v1
+    uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
 
   - name: Get current date
     id: date
@@ -48,7 +48,7 @@ runs:
 
   - name: Check Cache for Databases
     id: cache-check
-    uses: actions/cache@v4
+    uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
     with:
       path: ${{ github.workspace }}/.cache/trivy
       key: cache-trivy-${{ steps.date.outputs.date }}
@@ -72,7 +72,7 @@ runs:
       rm javadb.tar.gz
 
   - name: Cache DBs
-    uses: actions/cache/save@v4
+    uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
     if: ${{ !steps.cache-check.outputs.cache-hit }}
     with:
       path: ${{ github.workspace }}/.cache/trivy
@@ -96,7 +96,7 @@ runs:
       TRIVY_SKIP_JAVA_DB_UPDATE: true
 
   - name: Upload Trivy scan report to GitHub Security tab
-    uses: github/codeql-action/upload-sarif@v3
+    uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
     if: inputs.publish_vulnerabilities == 'true'
     with:
       sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- Pins all GitHub Actions in `shared-build-and-test.yaml` and its transitive dependency `actions/vulnerability_scan/action.yaml` to full-length commit SHAs
- Fixes: `The actions actions/checkout@v4, actions/setup-java@v4, actions/upload-artifact@v4, and iabtechlab/uid2-shared-actions/actions/vulnerability_scan@v3 are not allowed in UnifiedID2/uid2-okta-configuration because all actions must be pinned to a full-length commit SHA`
- Version comments (e.g. `# v4`) preserved next to each SHA for maintainability

### Actions pinned
| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4 | `34e11487` |
| `actions/setup-java` | v4 | `c1e32368` |
| `actions/upload-artifact` | v4 | `ea165f8d` |
| `actions/cache` | v4 | `0057852b` |
| `actions/cache/save` | v4 | `0057852b` |
| `oras-project/setup-oras` | v1 | `22ce207d` |
| `github/codeql-action/upload-sarif` | v3 | `5c8a8a64` |
| `IABTechLab/uid2-shared-actions/vulnerability_scan` | v3 | `aa84a60f` |

> **Note:** The self-reference to `uid2-shared-actions@v3` is pinned to the current v3 tag SHA. After this PR merges and the v3 tag is updated, the self-reference SHA should be updated to the new v3 commit.

## Test plan
- [ ] Verify the workflow runs successfully in a caller repo (e.g. uid2-okta-configuration)
- [ ] Confirm no SHA pinning errors from GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)