### PR TITLE
Fix vulnerability_scan self-reference SHA to include pinned actions

### DIFF
--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -72,7 +72,7 @@ jobs:
           path: ${{ inputs.working_dir }}/target/site/jacoco/*
 
       - name: Vulnerability Scan
-        uses: ./${{ inputs.working_dir }}/uid2-shared-actions/actions/vulnerability_scan
+        uses: ./uid2-shared-actions/actions/vulnerability_scan
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: ${{ inputs.vulnerability_severity }}

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -72,7 +72,7 @@ jobs:
           path: ${{ inputs.working_dir }}/target/site/jacoco/*
 
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@83defcc6516d8965a7807af3152c0b83f0b755ff # v3
+        uses: ./${{ inputs.working_dir }}/uid2-shared-actions/actions/vulnerability_scan
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: ${{ inputs.vulnerability_severity }}

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -72,7 +72,7 @@ jobs:
           path: ${{ inputs.working_dir }}/target/site/jacoco/*
 
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@aa84a60f4774fd78427d3882418dd913588abd8d # v3
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@83defcc6516d8965a7807af3152c0b83f0b755ff # v3
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: ${{ inputs.vulnerability_severity }}


### PR DESCRIPTION
## Summary
- Updates the self-reference `IABTechLab/uid2-shared-actions/actions/vulnerability_scan` SHA in `shared-build-and-test.yaml` from `aa84a60f` (old v3, unpinned) to `83defcc6` (new v3, with pinned SHAs)
- This is a follow-up to #212 — the original PR pinned all actions to SHAs, but the self-reference pointed to the old commit that still had unpinned `vulnerability_scan/action.yaml`

## Context
The error in uid2-okta-configuration changed from complaining about `checkout`, `setup-java`, `upload-artifact` to complaining about `checkout`, `setup-oras`, `cache`, `codeql-action/upload-sarif` — these are the actions inside `vulnerability_scan/action.yaml`, which was being resolved from the old (unpinned) SHA.

## ⚠️ After merging
The v3 tag must be moved again (create a new release like v3.72) so callers pick up this fix. **Then** the self-reference SHA in this file should be updated one final time to the new v3 commit.

## Test plan
- [ ] After merge + v3 tag update, re-run uid2-okta-configuration build and confirm no SHA pinning errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)