### PR TITLE
Add trivial reusable workflow for SHA pinning experiment

### DIFF
--- a/.github/workflows/trivial-reusable.yaml
+++ b/.github/workflows/trivial-reusable.yaml
@@ -1,0 +1,10 @@
+name: Trivial Reusable Workflow (no actions)
+on:
+  workflow_call:
+
+jobs:
+  hello:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No actions here, just a shell command
+        run: echo "This reusable workflow has no uses: steps, only run: steps"


### PR DESCRIPTION
Temporary: adds a minimal reusable workflow with only `run:` steps (no `uses:` actions) to test transitive SHA pinning enforcement behavior. Will be removed after the experiment.