### PR TITLE
Pin all unpinned actions in composite action files to SHAs

### DIFF
--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -41,14 +41,14 @@ runs:
 
     - name: Fail if Pre-release on Default branch
       if: ${{ inputs.release_type == 'Snapshot' && github.event.repository.default_branch == github.ref_name }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
           script: |
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
     - name: Fail if Release and not on Default branch or release-yyyy-q branch
       if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'release')}}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
           script: |
             core.setFailed('Releases can only be created on a Default or release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -54,7 +54,7 @@ runs:
         echo "num=${RANDOM}" >> $GITHUB_OUTPUT
 
     - name: Commit to new branch
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
       if: steps.changes.outputs.changes_exist == 'true'
       id: create-branch-and-commit
       with:
@@ -65,7 +65,7 @@ runs:
         add: ${{ inputs.add }}
         
     - name: Create PR
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       if: steps.changes.outputs.changes_exist == 'true'
       id: create-pr
       with:
@@ -92,7 +92,7 @@ runs:
         ADMIN_ACCESS: ${{ inputs.admin_access == 'true' && '--admin' || '' }}
     
     - name: Tag commit
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       id: tag-commit
       if: ${{ inputs.tag != '' && steps.changes.outputs.changes_exist == 'true' }}
       with:
@@ -112,7 +112,7 @@ runs:
           core.setOutput('commit_tag', '${{ inputs.tag }}');
 
     - name: Get commit SHA
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       id: get-commit-sha
       if: steps.changes.outputs.changes_exist == 'true'
       with:
@@ -126,7 +126,7 @@ runs:
           core.setOutput('commit_sha', pr.merge_commit_sha);
 
     - name: Print outputs
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       if: ${{ inputs.tag != '' && steps.changes.outputs.changes_exist == 'true' }}
       with:
         script: |

--- a/actions/delete_draft_releases/action.yaml
+++ b/actions/delete_draft_releases/action.yaml
@@ -6,7 +6,7 @@ runs:
 
   steps:
     - name: Delete draft releases
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       id: delete-release
       with:
         result-encoding: string

--- a/actions/prepare_gcp_metadata/action.yaml
+++ b/actions/prepare_gcp_metadata/action.yaml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Authenticate with Google Cloud
       id: gcp_auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
       with:
         token_format: access_token
         workload_identity_provider: ${{ inputs.gcp_workload_identity_provider_id }}
@@ -40,10 +40,10 @@ runs:
         access_token_lifetime: 1200s
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
     
     - name: Log in to the GCP Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ inputs.gcp_registry }}
         username: oauth2accesstoken

--- a/actions/shared_create_releases/action.yaml
+++ b/actions/shared_create_releases/action.yaml
@@ -31,7 +31,7 @@ runs:
     - name: Build Docker Changelog
       id: github_release_docker
       if: ${{ inputs.is_release == 'true' && inputs.publish_platform == 'Docker'}}
-      uses: mikepenz/release-changelog-builder-action@v4
+      uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
       with:
         toTag: v${{ inputs.new_version }}
         configurationJson: |
@@ -45,7 +45,7 @@ runs:
     - name: Build Maven Changelog
       id: github_release_maven
       if: ${{ inputs.is_release == 'true' && inputs.publish_platform == 'Maven'}}
-      uses: mikepenz/release-changelog-builder-action@v4
+      uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
       with:
         toTag: v${{ inputs.new_version }}
         configurationJson: |
@@ -58,7 +58,7 @@ runs:
 
     - name: Create Docker Release
       if: ${{ inputs.is_release == 'true' && inputs.publish_platform == 'Docker' }}
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
       with:
         name: v${{ inputs.new_version }}
         body: ${{ steps.github_release_docker.outputs.changelog }}
@@ -66,7 +66,7 @@ runs:
 
     - name: Create Maven Release
       if: ${{ inputs.is_release == 'true' && inputs.publish_platform == 'Maven'}}
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
       with:
         name: v${{ inputs.new_version }}
         body: ${{ steps.github_release_maven.outputs.changelog }}

--- a/actions/shared_publish_setup/action.yaml
+++ b/actions/shared_publish_setup/action.yaml
@@ -45,21 +45,21 @@ runs:
           IS_RELEASE: ${{ steps.checkRelease.outputs.IS_RELEASE }}
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       if: ${{ inputs.java_version != '' }}
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.java_version }}
 
     - name: Checkout full history on the commit that triggered the workflow
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       if: ${{ inputs.git_tag_or_hash == ''}}
       with:
         # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
         fetch-depth: 0
 
     - name: Checkout full history at tag ${{ inputs.git_tag_or_hash }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       if: ${{ inputs.git_tag_or_hash != ''}}
       with:
         ref: ${{ inputs.git_tag_or_hash }}
@@ -67,4 +67,4 @@ runs:
         fetch-depth: 0
 
     - name: Restore timestamps
-      uses: thetradedesk/git-restore-mtime-action@v1.3
+      uses: thetradedesk/git-restore-mtime-action@a6059d100648f8027eb1af5e6e6fd6e1328083af # v1.3

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -43,10 +43,10 @@ runs:
 
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Log in to the Docker container registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ inputs.docker_registry }}
         username: ${{ github.actor }}
@@ -54,7 +54,7 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: ${{ inputs.docker_registry }}/${{ inputs.docker_image_name }}
         tags: |
@@ -69,7 +69,7 @@ runs:
         echo "firstTag=$FIRST_TAG" >> $GITHUB_OUTPUT
 
     - name: Build and export to Docker
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: ${{ inputs.docker_context }}
         file: ${{ inputs.docker_file }}
@@ -90,7 +90,7 @@ runs:
         scan_type: ${{ inputs.scan_type }}
 
     - name: Push to Docker
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: ${{ inputs.docker_context }}
         file: ${{ inputs.docker_file }}

--- a/actions/start_aks_cluster/action.yaml
+++ b/actions/start_aks_cluster/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@v2
+      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/start_aks_private_operator/action.yaml
+++ b/actions/start_aks_private_operator/action.yaml
@@ -22,7 +22,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@v2
+      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/start_aws_private_operator/action.yaml
+++ b/actions/start_aws_private_operator/action.yaml
@@ -40,17 +40,17 @@ runs:
 
   steps:
     - name: Setup Python 3
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: 3.x
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v4
+      uses: py-actions/py-dependency-install@30aa0023464ed4b5b116bd9fbdab87acf01a484e # v4
       with:
         path: ./uid2-shared-actions/scripts/aws/requirements.txt
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
       with:
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::072245134533:role/github-runner-for-uid2-operator

--- a/actions/start_azure_private_operator/action.yaml
+++ b/actions/start_azure_private_operator/action.yaml
@@ -34,7 +34,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@v2
+      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/stop_aks_private_operator/action.yaml
+++ b/actions/stop_aks_private_operator/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@v2
+      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/stop_aws_private_operator/action.yaml
+++ b/actions/stop_aws_private_operator/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::072245134533:role/github-runner-for-uid2-operator

--- a/actions/stop_azure_private_operator/action.yaml
+++ b/actions/stop_azure_private_operator/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@v2
+      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/stop_gcp_private_operator/action.yaml
+++ b/actions/stop_gcp_private_operator/action.yaml
@@ -24,7 +24,7 @@ runs:
   steps:
     - name: Authenticate with Google Cloud
       id: gcp_auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
       with:
         token_format: access_token
         workload_identity_provider: ${{ inputs.gcp_workload_identity_provider_id }}
@@ -32,10 +32,10 @@ runs:
         access_token_lifetime: 1200s
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
       
     - name: Log in to the GCP Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ inputs.gcp_registry }}
         username: oauth2accesstoken

--- a/actions/update-major-version-tag/action.yaml
+++ b/actions/update-major-version-tag/action.yaml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Update major version tag
       id: updateTag
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const inputVersion = `${{ inputs.version }}`;

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -46,7 +46,7 @@ runs:
 
     - name: Set Version
       if:  inputs.version_number == ''
-      uses: dotnet/nbgv@master
+      uses: dotnet/nbgv@b944774b6878ef950cc14d1a72bf9c0ffafbb839 # master
       with:
         path: ${{ inputs.working_dir }}
         setAllVars: true


### PR DESCRIPTION
## Summary
- Pins all remaining unpinned `uses:` refs in composite action files (`actions/*/action.yaml`)
- 17 files, 38 replacements

## Why
[UID2-6913](https://thetradedesk.atlassian.net/browse/UID2-6913) PR #214 pinned third-party actions in workflow files (`.github/workflows/`) but missed composite action definitions under `actions/`. These composite actions are called by the workflows, so they carry the same supply chain risk.

Tracked in [UID2-6937](https://thetradedesk.atlassian.net/browse/UID2-6937).

## What's pinned

**Third-party:**
- `docker/setup-buildx-action@v3`, `docker/login-action@v3`, `docker/metadata-action@v5`, `docker/build-push-action@v5`
- `google-github-actions/auth@v2`, `google-github-actions/setup-gcloud@v2`
- `azure/login@v2` (5 files)
- `aws-actions/configure-aws-credentials@v4`
- `EndBug/add-and-commit@v9`, `dotnet/nbgv@master`
- `py-actions/py-dependency-install@v4`
- `mikepenz/release-changelog-builder-action@v4`, `softprops/action-gh-release@v2`
- `thetradedesk/git-restore-mtime-action@v1.3`

**GitHub-owned (also pinned while here):**
- `actions/github-script@v7`, `actions/setup-java@v4`, `actions/checkout@v4`, `actions/setup-python@v5`

## Not in scope
- IABTechLab self-references (`@v2`, `@v3`) — tracked separately
- Workflow files (`.github/workflows/`) — already pinned in PR #214

## Test plan
- [ ] Verify SHAs match expected tags via `git ls-remote`
- [ ] Confirm no remaining unpinned refs in `actions/` directory