### PR TITLE
Restore working_dir in vulnerability_scan path

### DIFF
--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -72,7 +72,7 @@ jobs:
           path: ${{ inputs.working_dir }}/target/site/jacoco/*
 
       - name: Vulnerability Scan
-        uses: ./uid2-shared-actions/actions/vulnerability_scan
+        uses: ./${{ inputs.working_dir }}/uid2-shared-actions/actions/vulnerability_scan
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: ${{ inputs.vulnerability_severity }}


### PR DESCRIPTION
## Summary
- Restores the `${{ inputs.working_dir }}` prefix in the vulnerability_scan action path in `shared-build-and-test.yaml`
- Reverts the change from ac528d1 which incorrectly simplified the path to `./uid2-shared-actions/actions/vulnerability_scan`, breaking callers that use a non-default working directory

## Test plan
- [ ] Verify CI passes on repos that call `shared-build-and-test` with a custom `working_dir`
- [ ] Verify CI passes on repos that use the default working directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)