### PR TITLE
Use commit_pr_and_merge@v3 in publish java workflow

### DIFF
--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Commit pom.xml and version.json
         if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.is_release != 'true' }}
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v2
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{inputs.working_dir}}/pom.xml version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
@@ -149,7 +149,7 @@ jobs:
 
       - name: Commit pom.xml, version.json and set tag
         if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.is_release == 'true' }}
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v2
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{inputs.working_dir}}/pom.xml version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'


### PR DESCRIPTION
Update `shared-publish-java-to-docker` workflow to use the latest version of `commit_pr_and_merge`.
 
**Differences between v2 and v3**: 
New optional inputs:
  - `base_branch` - default '' -> falls back to `github.ref_name`
  - `admin_access` - default false -> adds `--admin` flag to `gh pr merge` if true.
  - `github_token` - default '' -> falls back to `github.token`

New output:
  - `commit_sha`