### PR TITLE
UID2-6799 Call merge endpoint directly to honor ruleset bypass

### DIFF
--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Commit pom.xml and version.json
         if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.is_release != 'true' }}
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@swi-UID2-6799-commit-pr-and-merge-via-rest-api
         with:
           add: '${{inputs.working_dir}}/pom.xml version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
@@ -149,7 +149,7 @@ jobs:
 
       - name: Commit pom.xml, version.json and set tag
         if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.is_release == 'true' }}
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@swi-UID2-6799-commit-pr-and-merge-via-rest-api
         with:
           add: '${{inputs.working_dir}}/pom.xml version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'

--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Commit pom.xml and version.json
         if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.is_release != 'true' }}
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@swi-UID2-6799-commit-pr-and-merge-via-rest-api
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{inputs.working_dir}}/pom.xml version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
@@ -149,7 +149,7 @@ jobs:
 
       - name: Commit pom.xml, version.json and set tag
         if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.is_release == 'true' }}
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@swi-UID2-6799-commit-pr-and-merge-via-rest-api
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{inputs.working_dir}}/pom.xml version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -82,14 +82,19 @@ runs:
           core.setOutput('pull-request-number', newPr.number);
 
     - name: Merge PR
-      run: gh pr merge $PR_URL --delete-branch $MERGE_PR_STRATEGY $ADMIN_ACCESS
       if: steps.changes.outputs.changes_exist == 'true'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token == '' && github.token || inputs.github_token }}
-        PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
-        MERGE_PR_STRATEGY: ${{ github.ref_protected == 'true' && '--merge' || '--rebase' }}
-        ADMIN_ACCESS: ${{ inputs.admin_access == 'true' && '--admin' || '' }}
+        PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        BRANCH: 'ci-${{ github.sha }}-${{ steps.random-number.outputs.num }}'
+        MERGE_METHOD: ${{ github.ref_protected == 'true' && 'merge' || 'rebase' }}
+      run: |
+        gh api --method PUT \
+          "repos/${{ github.repository }}/pulls/$PR_NUMBER/merge" \
+          -f merge_method="$MERGE_METHOD"
+        gh api --method DELETE \
+          "repos/${{ github.repository }}/git/refs/heads/$BRANCH" || true
     
     - name: Tag commit
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -90,9 +90,13 @@ runs:
         BRANCH: 'ci-${{ github.sha }}-${{ steps.random-number.outputs.num }}'
         MERGE_METHOD: ${{ github.ref_protected == 'true' && 'merge' || 'rebase' }}
       run: |
+        # Merge the PR
         gh api --method PUT \
           "repos/${{ github.repository }}/pulls/$PR_NUMBER/merge" \
           -f merge_method="$MERGE_METHOD"
+
+        # Delete the branch
+        # || true - so the step doesn't fail if the branch is already deleted
         gh api --method DELETE \
           "repos/${{ github.repository }}/git/refs/heads/$BRANCH" || true
     

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -47,11 +47,10 @@ runs:
           echo "changes_exist=true" >> $GITHUB_OUTPUT
         fi
 
-    - name: Generate random number for branch
-      id: random-number
+    - name: Generate branch name
+      id: branch
       shell: bash
-      run: |
-        echo "num=${RANDOM}" >> $GITHUB_OUTPUT
+      run: echo "name=ci-${{ github.sha }}-${RANDOM}" >> $GITHUB_OUTPUT
 
     - name: Commit to new branch
       uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
@@ -61,9 +60,9 @@ runs:
         message: '[CI Pipeline] ${{ inputs.message }}'
         author_name: Release Workflow
         author_email: unifiedid-admin+release@thetradedesk.com
-        new_branch: 'ci-${{ github.sha }}-${{ steps.random-number.outputs.num }}'
+        new_branch: ${{ steps.branch.outputs.name }}
         add: ${{ inputs.add }}
-        
+
     - name: Create PR
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       if: steps.changes.outputs.changes_exist == 'true'
@@ -74,7 +73,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             title: '[CI Pipeline] ${{ inputs.message }}',
-            head: 'ci-${{ github.sha }}-${{ steps.random-number.outputs.num }}',
+            head: '${{ steps.branch.outputs.name }}',
             base: '${{ inputs.base_branch == '' && github.ref_name || inputs.base_branch }}',
             body: '[CI Pipeline] Automated update'
           })).data;
@@ -87,7 +86,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token == '' && github.token || inputs.github_token }}
         PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-        BRANCH: 'ci-${{ github.sha }}-${{ steps.random-number.outputs.num }}'
+        BRANCH: ${{ steps.branch.outputs.name }}
         MERGE_METHOD: ${{ github.ref_protected == 'true' && 'merge' || 'rebase' }}
       run: |
         # Merge the PR


### PR DESCRIPTION
## Summary

Replace `gh pr merge` with `gh api PUT .../merge` in `commit_pr_and_merge`.

## Why

`gh pr merge` reads `mergeStateStatus` client-side and refuses if `BLOCKED`. That status seems to be computed without regard for the caller's bypass rights, so PRs that would merge fine via a ruleset bypass actor get pre-emptively rejected with:

> `X Pull request ... is not mergeable: the base branch policy prohibits the merge.`

## Other changes
- Move branch name generation into its own step so it can be referenced