### PR TITLE
UID2-6799 Add merge_environment to remaining shared workflows

### DIFF
--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -14,6 +14,10 @@ on:
         description: The path to the directory for which the version should be determined.
         type: string
         default: '.'
+      merge_environment:
+        description: GitHub Environment to use for accessing the merge token. Leave empty to use the default GITHUB_TOKEN.
+        type: string
+        default: ''
     outputs:
       new_version:
         description: The new version number to publish for the docker repo
@@ -28,6 +32,7 @@ on:
 jobs:
   incrementVersionNumber:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.merge_environment }}
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
       image_tag: ${{ steps.updatePackageJson.outputs.image_tag }}
@@ -67,21 +72,23 @@ jobs:
           npm install --package-lock-only
 
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json and ${{ inputs.working_dir }}/version.json
-        if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE != 'true' }} 
+        if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE != 'true' }}
         id: commit-without-tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
+          github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Commit ${{ inputs.working_dir }}/package.json, ${{ inputs.working_dir }}/package-lock.json, ${{ inputs.working_dir }}/version.json and set tag
-        if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE == 'true' }} 
+        if: ${{ inputs.version_number_input == '' && steps.setup.outputs.IS_RELEASE == 'true' }}
         id: commit-and-tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@main
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{ inputs.working_dir }}/package.json ${{ inputs.working_dir }}/package-lock.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
           tag: v${{ steps.version.outputs.new_version }}
+          github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Print outputs
         uses: actions/github-script@v7

--- a/.github/workflows/shared-publish-to-ios-version.yaml
+++ b/.github/workflows/shared-publish-to-ios-version.yaml
@@ -10,6 +10,10 @@ on:
         description: The path to the directory for which the version should be determined.
         type: string
         default: '.'
+      merge_environment:
+        description: GitHub Environment to use for accessing the merge token. Leave empty to use the default GITHUB_TOKEN.
+        type: string
+        default: ''
 
 env:
   REPO: ${{ github.event.repository.name }}
@@ -18,6 +22,7 @@ jobs:
   release:
     name: Create Release
     runs-on: macos-15
+    environment: ${{ inputs.merge_environment }}
     permissions:
       pull-requests: write
       contents: write
@@ -86,11 +91,12 @@ jobs:
           xcodebuild test -scheme UID2Prebid -destination "OS=26.2,name=iPhone 17"
 
       - name: Commit SDK properties, podspecs, version.json and set tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v2
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift ${{ inputs.working_dir }}/UID2.podspec.json ${{ inputs.working_dir }}/UID2Prebid.podspec.json ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
-          tag: v${{ steps.version.outputs.new_version }}          
+          tag: v${{ steps.version.outputs.new_version }}
+          github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Build Changelog
         id: github_release

--- a/.github/workflows/shared-publish-to-nuget-versioned.yaml
+++ b/.github/workflows/shared-publish-to-nuget-versioned.yaml
@@ -20,6 +20,10 @@ on:
       publish_vulnerabilities:
         type: string
         default: "true"
+      merge_environment:
+        description: GitHub Environment to use for accessing the merge token. Leave empty to use the default GITHUB_TOKEN.
+        type: string
+        default: ''
 
 env:
   REPO: ${{ github.event.repository.name }}
@@ -28,6 +32,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    environment: ${{ inputs.merge_environment }}
     permissions:
       pull-requests: write
       contents: write
@@ -95,11 +100,12 @@ jobs:
           dotnet nuget push ./src/UID2.Client/bin/Release/UID2.Client.${{ steps.version.outputs.new_version }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
       - name: Commit UID2.Client.nuspec, version.json and set tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v2
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{ inputs.working_dir }}/UID2.Client.nuspec ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
-          tag: v${{ steps.version.outputs.new_version }}          
+          tag: v${{ steps.version.outputs.new_version }}
+          github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Build Changelog
         if: ${{ steps.checkRelease.outputs.is_release == 'true' }} 

--- a/.github/workflows/shared-publish-to-pypi-versioned.yaml
+++ b/.github/workflows/shared-publish-to-pypi-versioned.yaml
@@ -17,6 +17,10 @@ on:
       publish_vulnerabilities:
         type: string
         default: "true"
+      merge_environment:
+        description: GitHub Environment to use for accessing the merge token. Leave empty to use the default GITHUB_TOKEN.
+        type: string
+        default: ''
 
 env:
   REPO: ${{ github.event.repository.name }}
@@ -25,6 +29,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    environment: ${{ inputs.merge_environment }}
     permissions:
       pull-requests: write
       contents: write
@@ -85,11 +90,12 @@ jobs:
           python3 -m twine upload dist/* -u __token__ -p "${{ secrets.PYPI_API_KEY }}"
 
       - name: Commit pyproject.toml, version.json and set tag
-        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v2
+        uses: IABTechLab/uid2-shared-actions/actions/commit_pr_and_merge@v3
         with:
           add: '${{ inputs.working_dir }}/pyproject.toml ${{ inputs.working_dir }}/version.json'
           message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
-          tag: v${{ steps.version.outputs.new_version }}          
+          tag: v${{ steps.version.outputs.new_version }}
+          github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Build Changelog
         id: github_release


### PR DESCRIPTION
## Summary
Add `merge_environment` input to the 4 remaining shared workflows that call `commit_pr_and_merge`:
- `shared-publish-to-nuget-versioned.yaml`
- `shared-publish-to-pypi-versioned.yaml`
- `shared-publish-to-ios-version.yaml`
- `shared-increase-version-number.yaml`

When set, the job runs in the given environment (typically `ci-auto-merge`) and passes `GH_MERGE_TOKEN` to `commit_pr_and_merge` so the merge uses the UID2SourceAdmin PAT.

Also updates `commit_pr_and_merge@v2`/`@main` → `@v3` (older versions don't accept the `github_token` input).

Completes the shared workflow updates for UID2-6799.