### PR TITLE
UID2-6753: declare GH_MERGE_TOKEN as optional workflow_call secret

### DIFF
--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -51,16 +51,7 @@ on:
         value: ${{ jobs.buildImage.outputs.image_tag }}
     secrets:
       GH_MERGE_TOKEN:
-        description: |
-          PAT used by `commit_pr_and_merge` to merge the version-bump PR back to the default branch
-          when branch-protection rules require a bypass. Required when `merge_environment` is set and
-          the calling repository's default branch is protected by a PR-review ruleset that GITHUB_TOKEN
-          cannot bypass. Otherwise optional — without it, the action falls back to GITHUB_TOKEN.
-
-          Pass via `secrets: inherit` (works when the secret is at org level, or at env level when caller
-          and reusable workflow are in the same enterprise), or explicitly via
-          `secrets: { GH_MERGE_TOKEN: ${{ secrets.GH_MERGE_TOKEN }} }` (works cross-organization).
-          See https://github.com/actions/runner/issues/1490 for the cross-org inheritance limitation.
+        description: PAT used by commit_pr_and_merge to bypass branch protection on the auto-PR. Falls back to GITHUB_TOKEN if not set.
         required: false
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -49,6 +49,19 @@ on:
       image_tag:
         description: The tag used to describe the image in docker
         value: ${{ jobs.buildImage.outputs.image_tag }}
+    secrets:
+      GH_MERGE_TOKEN:
+        description: |
+          PAT used by `commit_pr_and_merge` to merge the version-bump PR back to the default branch
+          when branch-protection rules require a bypass. Required when `merge_environment` is set and
+          the calling repository's default branch is protected by a PR-review ruleset that GITHUB_TOKEN
+          cannot bypass. Otherwise optional — without it, the action falls back to GITHUB_TOKEN.
+
+          Pass via `secrets: inherit` (works when the secret is at org level, or at env level when caller
+          and reusable workflow are in the same enterprise), or explicitly via
+          `secrets: { GH_MERGE_TOKEN: ${{ secrets.GH_MERGE_TOKEN }} }` (works cross-organization).
+          See https://github.com/actions/runner/issues/1490 for the cross-org inheritance limitation.
+        required: false
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Declares `GH_MERGE_TOKEN` as an optional `workflow_call.secrets` entry on `shared-publish-java-to-docker-versioned.yaml`. Existing callers are unaffected; cross-organization callers can now pass the token explicitly.

## Problem

The reusable workflow needs a PAT (`GH_MERGE_TOKEN`) to merge the version-bump PR back to the default branch when branch protection requires bypass. The expression
```yaml
github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
```
relies on the secret being available inside this workflow's `secrets` context.

When the caller is in the **same organization** (e.g. `IABTechLab/uid2-core`), `secrets: inherit` plus the called job's `environment: ci-auto-merge` correctly exposes the env-scoped secret to the called workflow, and `commit_pr_and_merge` receives the token (verified — see `with: github_token: ***` in any recent uid2-core release).

When the caller is in a **different organization** (e.g. `UnifiedID2/uid2-snowflake`), `secrets: inherit` does **not** propagate environment-scoped secrets to the called workflow's `secrets` context. The expression collapses to `''`, `commit_pr_and_merge` falls back to `GITHUB_TOKEN`, which has no bypass on the caller's PR-review ruleset, and the merge step fails with HTTP 405 *"New changes require approval from someone other than the last pusher"* — see the failure on [UnifiedID2/uid2-snowflake#25202341348](https://github.com/UnifiedID2/uid2-snowflake/actions/runs/25202341348/job/73895782186).

References:
- [Reusing workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows) — `secrets: inherit` and the `secrets:` map on a `uses:` job.
- [actions/runner#1490](https://github.com/actions/runner/issues/1490) — environment-scoped secrets are not injected into cross-repo reusable workflow jobs.

## Change

Add an optional `secrets:` declaration to `workflow_call`:
```yaml
secrets:
  GH_MERGE_TOKEN:
    description: ...
    required: false
```

The existing two `github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}` references are unchanged.

## Why this is backward compatible

- Callers that use `secrets: inherit` continue to work exactly as before. Declaring a secret on `workflow_call.secrets` does not change `inherit` semantics.
- Callers that pass nothing (no `secrets:` block at all) continue to work — the optional secret is empty, `inputs.merge_environment` is `''` by default, and the action falls back to `GITHUB_TOKEN`. This matches today's behaviour for callers that don't opt into auto-merge.
- Cross-organization callers can now opt into explicit pass-through:
  ```yaml
  secrets:
    GH_MERGE_TOKEN: ${{ secrets.GH_MERGE_TOKEN }}
  ```
  This requires the caller's repo to have `GH_MERGE_TOKEN` accessible at repo or org level (a job that calls a reusable workflow cannot itself declare `environment:`, so env-scoped-only secrets are not readable in the caller's evaluation context).

## Follow-up

A companion PR will switch `UnifiedID2/uid2-snowflake/.github/workflows/publish-docker.yaml` to the explicit pass form, paired with the org-level `GH_MERGE_TOKEN` recently added in `uid2-okta-configuration` (commit `2714fb1`).

## Test plan

- [ ] Merge, confirm `v3` floating tag advances.
- [ ] Trigger `IABTechLab/uid2-core` release on `main` — should still succeed via `secrets: inherit` (no caller change).
- [ ] After companion snowflake PR merges, trigger `UnifiedID2/uid2-snowflake/publish-docker.yaml` on `main` — should succeed; `commit_pr_and_merge` step should show `github_token: ***` in its inputs.