### PR TITLE
UID2-6995 Add --omit-id for Azure policy gen

### DIFF
--- a/scripts/aks/prepare_aks_artifacts.sh
+++ b/scripts/aks/prepare_aks_artifacts.sh
@@ -129,7 +129,7 @@ else
   fi
 
   # Generate policy using debug mode as we will need to override environment variables
-  yes | az confcom acipolicygen --virtual-node-yaml ${OUTPUT_TEMPLATE_FILE} --debug-mode > ${OUTPUT_POLICY_DIGEST_FILE}
+  yes | az confcom acipolicygen --omit-id --virtual-node-yaml ${OUTPUT_TEMPLATE_FILE} --debug-mode > ${OUTPUT_POLICY_DIGEST_FILE}
   if [[ $? -ne 0 ]]; then
     echo "Failed to generate template file"
     exit 1

--- a/scripts/azure/artifacts_schema/template.json
+++ b/scripts/azure/artifacts_schema/template.json
@@ -118,10 +118,6 @@
               },
               "environmentVariables": [
                 {
-                  "name": "IMAGE_NAME",
-                  "value": "IMAGE_PLACEHOLDER"
-                },
-                {
                   "name": "VAULT_NAME",
                   "value": "[parameters('vaultName')]"
                 },

--- a/scripts/azure/prepare_azure_artifacts.sh
+++ b/scripts/azure/prepare_azure_artifacts.sh
@@ -49,7 +49,7 @@ else
     exit 1
   fi
 
-  az confcom acipolicygen --approve-wildcards --template-file ${OUTPUT_TEMPLATE_FILE} > ${OUTPUT_POLICY_DIGEST_FILE}
+  az confcom acipolicygen --approve-wildcards --omit-id --template-file ${OUTPUT_TEMPLATE_FILE} > ${OUTPUT_POLICY_DIGEST_FILE}
   if [[ $? -ne 0 ]]; then
     echo "Failed to generate template file"
     exit 1


### PR DESCRIPTION
Shared-actions counterpart to the operator-side change (IABTechLab/uid2-operator#2567).

- Add `--omit-id` to `acipolicygen` in the Azure (CC) and AKS artifact-prep scripts → drops the `id` field.
- Remove the `IMAGE_NAME` env var from the Azure `template.json` → drops the `IMAGE_NAME` env rule.

`id` and `IMAGE_NAME` are registry-dependent metadata; the dm-verity `layers` remain the cryptographic image identity, so a mirrored byte-identical image produces the **same** enclave ID and attests against the same registration. Security unchanged.