### PR TITLE
chore: upgrade GitHub Actions from Node 20 to Node 24

### DIFF
--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -199,7 +199,7 @@ jobs:
           echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{inputs.working_dir}}
           load: true
@@ -220,7 +220,7 @@ jobs:
 
       - name: Push to Docker (by digest, untagged)
         id: push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{inputs.working_dir}}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/shared-validate-image.yaml
+++ b/.github/workflows/shared-validate-image.yaml
@@ -86,7 +86,7 @@ jobs:
             type=sha,prefix=${{ steps.package.outputs.jar_version }}-,suffix=-${{ inputs.cloud_provider }},format=short
 
       - name: Build Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           load: true

--- a/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build Docker image
         if: inputs.scan_type == 'image'
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{inputs.working_dir}}
           load: true


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Starting **June 16, 2026**, runners will use Node 24 by default.

This PR upgrades all outdated action references in this repo.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
