### PR TITLE
chore: upgrade GitHub Actions from Node 20 to Node 24

### DIFF
--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout uid2-shared-actions repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v3
           repository: IABTechLab/uid2-shared-actions
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set up JDK
         if: ${{ inputs.vulnerability_scan_only == 'false' }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Archive code coverage results
         if: ${{ inputs.vulnerability_scan_only == 'false' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage-report
           path: ${{ inputs.working_dir }}/target/site/jacoco/*

--- a/.github/workflows/shared-check-stable-dependency.yaml
+++ b/.github/workflows/shared-check-stable-dependency.yaml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Resolve dependencies
         run: mvn -B dependency:resolve

--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           release_type: ${{ inputs.release_type }}
       
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -91,7 +91,7 @@ jobs:
           github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Print outputs
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             console.log('Result', '${{ steps.commit-and-tag.outcome }}');

--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -44,10 +44,6 @@ jobs:
         with:
           release_type: ${{ inputs.release_type }}
       
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
-
       - name: Set version number
         id: version
         uses: IABTechLab/uid2-shared-actions/actions/version_number@v2
@@ -65,6 +61,10 @@ jobs:
           jq --arg v "$new_version" ".version = \$v" "${{ inputs.working_dir }}/package.json" > tmp.json && mv tmp.json "${{ inputs.working_dir }}/package.json"
           echo "Version number updated from $current_version to $new_version"
           echo "image_tag=${{ steps.version.outputs.new_version }}" >> $GITHUB_OUTPUT
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
 
       - name: Update ${{ inputs.working_dir }}/package-lock.json
         id: updatePackageLockJson

--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -91,9 +91,7 @@ jobs:
           github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Print outputs
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            console.log('Result', '${{ steps.commit-and-tag.outcome }}');
-            console.log('Commit and tag', '${{ steps.commit-and-tag.outputs.git_tag_or_hash }}');
-            console.log('No tag', '${{ steps.commit-without-tag.outputs.git_tag_or_hash }}');
+        run: |
+          echo "Result: ${{ steps.commit-and-tag.outcome }}"
+          echo "Commit and tag: ${{ steps.commit-and-tag.outputs.git_tag_or_hash }}"
+          echo "No tag: ${{ steps.commit-without-tag.outputs.git_tag_or_hash }}"

--- a/.github/workflows/shared-promote-auto-pr.yaml
+++ b/.github/workflows/shared-promote-auto-pr.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create Pull Request
         run: |
           echo "branch ${{ github.ref }} was pushed to"

--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -94,20 +94,20 @@ jobs:
             IS_RELEASE: ${{ steps.checkRelease.outputs.is_release }}
   
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
 
       - name: Checkout full history on Main
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ inputs.version_number_input == ''}}
         with:
           # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
           fetch-depth: 0
 
       - name: Checkout full history at tag v${{ inputs.version_number_input }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ inputs.version_number_input != ''}}
         with:
           ref: v${{ inputs.version_number_input }}
@@ -168,7 +168,7 @@ jobs:
           github_token: ${{ inputs.merge_environment != '' && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Log in to the Docker container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -176,7 +176,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ inputs.append_image_name }}
           tags: |
@@ -190,7 +190,7 @@ jobs:
           echo "firstTag=$FIRST_TAG" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Lowercase image reference
         id: imageRef
@@ -199,7 +199,7 @@ jobs:
           echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{inputs.working_dir}}
           load: true
@@ -220,7 +220,7 @@ jobs:
 
       - name: Push to Docker (by digest, untagged)
         id: push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{inputs.working_dir}}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/shared-publish-to-ios-version.yaml
+++ b/.github/workflows/shared-publish-to-ios-version.yaml
@@ -44,7 +44,7 @@ jobs:
           release_type: ${{ inputs.release_type }}
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/shared-publish-to-maven-versioned.yaml
+++ b/.github/workflows/shared-publish-to-maven-versioned.yaml
@@ -68,19 +68,19 @@ jobs:
           release_type: ${{ inputs.release_type }}
     
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Checkout uid2-shared-actions repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v3
           repository: IABTechLab/uid2-shared-actions
           path: uid2-shared-actions
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}

--- a/.github/workflows/shared-publish-to-nuget-versioned.yaml
+++ b/.github/workflows/shared-publish-to-nuget-versioned.yaml
@@ -54,12 +54,12 @@ jobs:
           release_type: ${{ inputs.release_type }}
     
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup dotnet ${{ inputs.dotnet_version }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 

--- a/.github/workflows/shared-publish-to-pypi-versioned.yaml
+++ b/.github/workflows/shared-publish-to-pypi-versioned.yaml
@@ -51,7 +51,7 @@ jobs:
           release_type: ${{ inputs.release_type }}
     
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/shared-run-e2e-tests.yaml
+++ b/.github/workflows/shared-run-e2e-tests.yaml
@@ -111,52 +111,52 @@ jobs:
       aws_stack_name: ${{ steps.start_aws_private_operator.outputs.aws_stack_name }}
     steps:
       - name: Log in to the Docker container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout uid2-operator repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.operator_branch }}
           repository: IABTechLab/uid2-operator
           path: uid2-operator
 
       - name: Checkout uid2-core repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.core_branch }}
           repository: IABTechLab/uid2-core
           path: uid2-core
 
       - name: Checkout uid2-optout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.optout_branch }}
           repository: IABTechLab/uid2-optout
           path: uid2-optout
 
       - name: Checkout uid2-admin repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.admin_branch }}
           repository: IABTechLab/uid2-admin
           path: uid2-admin
 
       - name: Checkout uid2-shared-actions repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v3
           repository: IABTechLab/uid2-shared-actions
           path: uid2-shared-actions
 
       - name: Checkout uid2-e2e repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: IABTechLab/uid2-e2e
           path: uid2-e2e
@@ -375,7 +375,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout uid2-shared-actions repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v3
           repository: IABTechLab/uid2-shared-actions

--- a/.github/workflows/shared-validate-image.yaml
+++ b/.github/workflows/shared-validate-image.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
           fetch-depth: 0
@@ -53,7 +53,7 @@ jobs:
         uses: thetradedesk/git-restore-mtime-action@a6059d100648f8027eb1af5e6e6fd6e1328083af # v1.3
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
@@ -71,7 +71,7 @@ jobs:
           echo "git_commit=$(git show --format="%h" --no-patch)" >> $GITHUB_OUTPUT
 
       - name: Log in to the Docker container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -79,14 +79,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=${{ steps.package.outputs.jar_version }}-,suffix=-${{ inputs.cloud_provider }},format=short
 
       - name: Build Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           load: true

--- a/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout uid2-shared-actions repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v3
           repository: IABTechLab/uid2-shared-actions
@@ -51,7 +51,7 @@ jobs:
 
       - name: Set up JDK
         if: inputs.scan_type == 'image'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build Docker image
         if: inputs.scan_type == 'image'
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{inputs.working_dir}}
           load: true


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Starting **June 16, 2026**, runners will use Node 24 by default.

This PR upgrades outdated action references in this repo to the latest released version that ships Node 24 support, pinned to its commit SHA. Each action's node version is determined by reading its `action.yml` at the pinned ref.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
