### PR TITLE
UID2-6742: chore: upgrade composite actions from Node 20 to Node 24

### DIFF
--- a/actions/shared_publish_setup/action.yaml
+++ b/actions/shared_publish_setup/action.yaml
@@ -52,14 +52,14 @@ runs:
         java-version: ${{ inputs.java_version }}
 
     - name: Checkout full history on the commit that triggered the workflow
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       if: ${{ inputs.git_tag_or_hash == ''}}
       with:
         # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
         fetch-depth: 0
 
     - name: Checkout full history at tag ${{ inputs.git_tag_or_hash }}
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       if: ${{ inputs.git_tag_or_hash != ''}}
       with:
         ref: ${{ inputs.git_tag_or_hash }}

--- a/actions/vulnerability_scan/action.yaml
+++ b/actions/vulnerability_scan/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
   - name: Checkout repo
-    uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     with:
       repository: IABTechLab/uid2-shared-actions
       ref: v3
@@ -39,7 +39,7 @@ runs:
       rm -rf tmp-vulnerability-scan
 
   - name: Setup oras
-    uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+    uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
 
   - name: Get current date
     id: date
@@ -48,7 +48,7 @@ runs:
 
   - name: Check Cache for Databases
     id: cache-check
-    uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+    uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
     with:
       path: ${{ github.workspace }}/.cache/trivy
       key: cache-trivy-${{ steps.date.outputs.date }}
@@ -72,7 +72,7 @@ runs:
       rm javadb.tar.gz
 
   - name: Cache DBs
-    uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+    uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
     if: ${{ !steps.cache-check.outputs.cache-hit }}
     with:
       path: ${{ github.workspace }}/.cache/trivy
@@ -96,7 +96,7 @@ runs:
       TRIVY_SKIP_JAVA_DB_UPDATE: true
 
   - name: Upload Trivy scan report to GitHub Security tab
-    uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+    uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
     if: inputs.publish_vulnerabilities == 'true'
     with:
       sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary

PR #237 upgraded action versions in all `.github/workflows/` files, but missed two composite actions under `actions/`:

- `actions/vulnerability_scan/action.yaml`: `actions/checkout` (v4→v6), `oras-project/setup-oras` (v1→v2), `actions/cache` (v4→v5), `actions/cache/save` (v4→v5), `github/codeql-action/upload-sarif` (v3→v4)
- `actions/shared_publish_setup/action.yaml`: `actions/checkout` (v4→v6)

All updated versions use `node24`. GitHub is forcing Node 24 as default from June 16 2026.

## Test plan
- [ ] Verify the `Build and Test` run on a consumer repo (e.g. uid2-operator) no longer shows Node 20 deprecation warnings after bumping to the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)