### PR TITLE
UID2-6742: chore: upgrade trivy-action from v0.35.0 to v0.36.0

### DIFF
--- a/actions/vulnerability_scan/action.yaml
+++ b/actions/vulnerability_scan/action.yaml
@@ -79,7 +79,7 @@ runs:
       key: cache-trivy-${{ steps.date.outputs.date }}
 
   - name: Generate Trivy vulnerability scan report
-    uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+    uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
     if: inputs.publish_vulnerabilities == 'true'
     with:
       image-ref: ${{ inputs.image_ref }}
@@ -103,7 +103,7 @@ runs:
 
   - name: Local vulnerability scanner for MEDIUM,HIGH,CRITICAL for reporting
     if: ${{ inputs.full_report  == 'true' }}
-    uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+    uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
     with:
       image-ref: ${{ inputs.image_ref }}
       scan-type: ${{ inputs.scan_type }}
@@ -119,7 +119,7 @@ runs:
       TRIVY_DEPENDENCY_TREE: true
 
   - name: Test with Trivy vulnerability scanner
-    uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+    uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
     with:
       image-ref: ${{ inputs.image_ref }}
       scan-type: ${{ inputs.scan_type }}

--- a/actions/vulnerability_scan/action.yaml
+++ b/actions/vulnerability_scan/action.yaml
@@ -79,7 +79,7 @@ runs:
       key: cache-trivy-${{ steps.date.outputs.date }}
 
   - name: Generate Trivy vulnerability scan report
-    uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+    uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
     if: inputs.publish_vulnerabilities == 'true'
     with:
       image-ref: ${{ inputs.image_ref }}
@@ -103,7 +103,7 @@ runs:
 
   - name: Local vulnerability scanner for MEDIUM,HIGH,CRITICAL for reporting
     if: ${{ inputs.full_report  == 'true' }}
-    uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+    uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
     with:
       image-ref: ${{ inputs.image_ref }}
       scan-type: ${{ inputs.scan_type }}
@@ -119,7 +119,7 @@ runs:
       TRIVY_DEPENDENCY_TREE: true
 
   - name: Test with Trivy vulnerability scanner
-    uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+    uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
     with:
       image-ref: ${{ inputs.image_ref }}
       scan-type: ${{ inputs.scan_type }}


### PR DESCRIPTION
## Summary

After fixing the other Node 20 actions in #238, one warning remained:

```
actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
```

This is `actions/cache@v4.2.4` (Node 20), called internally by `aquasecurity/trivy-action@v0.35.0` in its "Restore DB from cache" step. The `cache` input defaults to `'true'` so this step always runs.

`trivy-action@v0.36.0` upgrades the internal cache call to `actions/cache@v5.0.5` (Node 24), fixing the final warning.

## Test plan
- [ ] Re-run the uid2-operator Build and Test workflow after this fix is released — expect zero Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)