### PR TITLE
chore: upgrade IABTechLab/uid2-shared-actions from v2 to v3

### DIFF
--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -40,13 +40,13 @@ jobs:
     steps:
       - name: Setup
         id: setup
-        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@v2
+        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@v3
         with:
           release_type: ${{ inputs.release_type }}
       
       - name: Set version number
         id: version
-        uses: IABTechLab/uid2-shared-actions/actions/version_number@v2
+        uses: IABTechLab/uid2-shared-actions/actions/version_number@v3
         with:
           type: ${{ inputs.release_type }}
           version_number: ${{ inputs.version_number_input }}

--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Set version number
         id: version
-        uses: IABTechLab/uid2-shared-actions/actions/version_number@v2
+        uses: IABTechLab/uid2-shared-actions/actions/version_number@v3
         with:
           type: ${{ inputs.release_type }}
           version_number: ${{ inputs.version_number_input }}

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Setup
         id: setup
-        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@v2
+        uses: IABTechLab/uid2-shared-actions/actions/shared_publish_setup@v3
         with:
           release_type: ${{ inputs.release_type }}
           git_tag_or_hash: ${{ inputs.git_tag_or_hash }}

--- a/.github/workflows/shared-publish-to-ios-version.yaml
+++ b/.github/workflows/shared-publish-to-ios-version.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check branch and release type
         id: checkRelease
-        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2
+        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v3
         with:
           release_type: ${{ inputs.release_type }}
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set version number
         id: version
-        uses: IABTechLab/uid2-shared-actions/actions/version_number@v2
+        uses: IABTechLab/uid2-shared-actions/actions/version_number@v3
         with:
           type: ${{ inputs.release_type }}
           branch_name: ${{ github.ref }}

--- a/.github/workflows/shared-publish-to-maven-versioned.yaml
+++ b/.github/workflows/shared-publish-to-maven-versioned.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Check branch and release type
         id: checkRelease
-        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2
+        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v3
         with:
           release_type: ${{ inputs.release_type }}
     
@@ -86,7 +86,7 @@ jobs:
           java-version: ${{ inputs.java_version }}
 
       - name: Download key
-        uses: IABTechLab/uid2-shared-actions/actions/download_gpg_key@v2
+        uses: IABTechLab/uid2-shared-actions/actions/download_gpg_key@v3
         with:
           key: ${{ secrets.GPG_KEY }}
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Set version number
         id: version
-        uses: IABTechLab/uid2-shared-actions/actions/version_number@v2
+        uses: IABTechLab/uid2-shared-actions/actions/version_number@v3
         with:
           type: ${{ inputs.release_type }}
           branch_name: ${{ github.ref }}

--- a/.github/workflows/shared-publish-to-nuget-versioned.yaml
+++ b/.github/workflows/shared-publish-to-nuget-versioned.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Check branch and release type
         id: checkRelease
-        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2
+        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v3
         with:
           release_type: ${{ inputs.release_type }}
     
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set version number
         id: version
-        uses: IABTechLab/uid2-shared-actions/actions/version_number@v2
+        uses: IABTechLab/uid2-shared-actions/actions/version_number@v3
         with:
           type: ${{ inputs.release_type }}
           branch_name: ${{ github.ref }}

--- a/.github/workflows/shared-publish-to-pypi-versioned.yaml
+++ b/.github/workflows/shared-publish-to-pypi-versioned.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Check branch and release type
         id: checkRelease
-        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2
+        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v3
         with:
           release_type: ${{ inputs.release_type }}
     
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set version number
         id: version
-        uses: IABTechLab/uid2-shared-actions/actions/version_number@v2
+        uses: IABTechLab/uid2-shared-actions/actions/version_number@v3
         with:
           type: ${{ inputs.release_type }}
           branch_name: ${{ github.ref }}

--- a/.github/workflows/update-major-version-tags.yaml
+++ b/.github/workflows/update-major-version-tags.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update major version
-        uses: IABTechLab/uid2-shared-actions/actions/update-major-version-tag@v2
+        uses: IABTechLab/uid2-shared-actions/actions/update-major-version-tag@v3
         continue-on-error: true
         with:
           version: ${{ github.event.release.tag_name }}

--- a/actions/shared_publish_setup/action.yaml
+++ b/actions/shared_publish_setup/action.yaml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Check branch and release type
       id: checkRelease
-      uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2
+      uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v3
       with:
         release_type: ${{ inputs.release_type }}
         force_release: ${{ inputs.force_release }}


### PR DESCRIPTION
This PR bumps all `IABTechLab/uid2-shared-actions` references in this repo from the `@v2` major tag to `@v3`.
