### PR TITLE
chore: upgrade GitHub Actions from Node 20 to Node 24

### DIFF
--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -41,14 +41,14 @@ runs:
 
     - name: Fail if Pre-release on Default branch
       if: ${{ inputs.release_type == 'Snapshot' && github.event.repository.default_branch == github.ref_name }}
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
           script: |
             core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
 
     - name: Fail if Release and not on Default branch or release-yyyy-q branch
       if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'release')}}
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
           script: |
             core.setFailed('Releases can only be created on a Default or release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -53,7 +53,7 @@ runs:
       run: echo "name=ci-${{ github.sha }}-${RANDOM}" >> $GITHUB_OUTPUT
 
     - name: Commit to new branch
-      uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
+      uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
       if: steps.changes.outputs.changes_exist == 'true'
       id: create-branch-and-commit
       with:
@@ -64,7 +64,7 @@ runs:
         add: ${{ inputs.add }}
 
     - name: Create PR
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       if: steps.changes.outputs.changes_exist == 'true'
       id: create-pr
       with:
@@ -100,7 +100,7 @@ runs:
           "repos/${{ github.repository }}/git/refs/heads/$BRANCH" || true
     
     - name: Tag commit
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: tag-commit
       if: ${{ inputs.tag != '' && steps.changes.outputs.changes_exist == 'true' }}
       with:
@@ -120,7 +120,7 @@ runs:
           core.setOutput('commit_tag', '${{ inputs.tag }}');
 
     - name: Get commit SHA
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: get-commit-sha
       if: steps.changes.outputs.changes_exist == 'true'
       with:
@@ -134,7 +134,7 @@ runs:
           core.setOutput('commit_sha', pr.merge_commit_sha);
 
     - name: Print outputs
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       if: ${{ inputs.tag != '' && steps.changes.outputs.changes_exist == 'true' }}
       with:
         script: |

--- a/actions/delete_draft_releases/action.yaml
+++ b/actions/delete_draft_releases/action.yaml
@@ -6,7 +6,7 @@ runs:
 
   steps:
     - name: Delete draft releases
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: delete-release
       with:
         result-encoding: string

--- a/actions/prepare_gcp_metadata/action.yaml
+++ b/actions/prepare_gcp_metadata/action.yaml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Authenticate with Google Cloud
       id: gcp_auth
-      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         token_format: access_token
         workload_identity_provider: ${{ inputs.gcp_workload_identity_provider_id }}
@@ -40,10 +40,10 @@ runs:
         access_token_lifetime: 1200s
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
     
     - name: Log in to the GCP Registry
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.gcp_registry }}
         username: oauth2accesstoken

--- a/actions/shared_create_releases/action.yaml
+++ b/actions/shared_create_releases/action.yaml
@@ -190,7 +190,7 @@ runs:
     - name: Build changelog
       id: changelog
       if: ${{ inputs.is_release == 'true' }}
-      uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
+      uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
       with:
         toTag: v${{ inputs.new_version }}
         fromTag: ${{ inputs.from_tag }}
@@ -204,7 +204,7 @@ runs:
 
     - name: Create Release
       if: ${{ inputs.is_release == 'true' }}
-      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       with:
         name: v${{ inputs.new_version }}
         body: ${{ steps.changelog.outputs.changelog }}

--- a/actions/shared_publish_setup/action.yaml
+++ b/actions/shared_publish_setup/action.yaml
@@ -45,7 +45,7 @@ runs:
           IS_RELEASE: ${{ steps.checkRelease.outputs.IS_RELEASE }}
 
     - name: Set up JDK
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       if: ${{ inputs.java_version != '' }}
       with:
         distribution: 'temurin'

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -46,10 +46,10 @@ runs:
 
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Log in to the Docker container registry
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.docker_registry }}
         username: ${{ github.actor }}
@@ -57,7 +57,7 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       with:
         images: ${{ inputs.docker_registry }}/${{ inputs.docker_image_name }}
         tags: |
@@ -79,7 +79,7 @@ runs:
         echo "value=${value}" >> "$GITHUB_OUTPUT"
 
     - name: Build and export to Docker
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: ${{ inputs.docker_context }}
         file: ${{ inputs.docker_file }}
@@ -101,7 +101,7 @@ runs:
 
     - name: Push to Docker (by digest, untagged)
       id: push
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: ${{ inputs.docker_context }}
         file: ${{ inputs.docker_file }}

--- a/actions/start_aks_cluster/action.yaml
+++ b/actions/start_aks_cluster/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/start_aks_private_operator/action.yaml
+++ b/actions/start_aks_private_operator/action.yaml
@@ -22,7 +22,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/start_aws_private_operator/action.yaml
+++ b/actions/start_aws_private_operator/action.yaml
@@ -40,7 +40,7 @@ runs:
 
   steps:
     - name: Setup Python 3
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.x
 
@@ -50,7 +50,7 @@ runs:
         path: ./uid2-shared-actions/scripts/aws/requirements.txt
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::072245134533:role/github-runner-for-uid2-operator

--- a/actions/start_azure_private_operator/action.yaml
+++ b/actions/start_azure_private_operator/action.yaml
@@ -34,7 +34,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/stop_aks_private_operator/action.yaml
+++ b/actions/stop_aks_private_operator/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/stop_aws_private_operator/action.yaml
+++ b/actions/stop_aws_private_operator/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::072245134533:role/github-runner-for-uid2-operator

--- a/actions/stop_azure_private_operator/action.yaml
+++ b/actions/stop_azure_private_operator/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Log in to Azure
-      uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       with:
         creds: ${{ inputs.azure_credentials }}
         enable-AzPSSession: true

--- a/actions/stop_gcp_private_operator/action.yaml
+++ b/actions/stop_gcp_private_operator/action.yaml
@@ -24,7 +24,7 @@ runs:
   steps:
     - name: Authenticate with Google Cloud
       id: gcp_auth
-      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         token_format: access_token
         workload_identity_provider: ${{ inputs.gcp_workload_identity_provider_id }}
@@ -32,10 +32,10 @@ runs:
         access_token_lifetime: 1200s
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       
     - name: Log in to the GCP Registry
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.gcp_registry }}
         username: oauth2accesstoken

--- a/actions/update-major-version-tag/action.yaml
+++ b/actions/update-major-version-tag/action.yaml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Update major version tag
       id: updateTag
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const inputVersion = `${{ inputs.version }}`;


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Starting **June 16, 2026**, runners will use Node 24 by default.

This PR upgrades outdated action references in this repo to the latest released version that ships Node 24 support, pinned to its commit SHA. Each action's node version is determined by reading its `action.yml` at the pinned ref.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
