### PR TITLE
UID2-7390: add optional image_ref to shared vuln-scan notify workflow

### DIFF
--- a/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
@@ -30,6 +30,15 @@ on:
         description: The path to the pom.xml and Dockerfile.
         type: string
         default: '.'
+      image_ref:
+        description: >-
+          An already-published image reference to scan (e.g. ghcr.io/org/app:latest). When set,
+          the JDK/Maven/Docker-build steps are skipped and this image is scanned directly — use this
+          to re-scan released images for newly-disclosed CVEs. When empty (the default), behaviour is
+          unchanged: image mode builds from source. The image must be pullable without auth (or the
+          caller must log in to the registry before invoking this workflow).
+        type: string
+        default: ''
     secrets:
       SLACK_WEBHOOK:
         required: false
@@ -50,14 +59,14 @@ jobs:
           path: uid2-shared-actions
 
       - name: Set up JDK
-        if: inputs.scan_type == 'image'
+        if: inputs.scan_type == 'image' && inputs.image_ref == ''
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
 
       - name: Package JAR
-        if: inputs.scan_type == 'image'
+        if: inputs.scan_type == 'image' && inputs.image_ref == ''
         id: package
         run: |
           pushd ${{ inputs.working_dir }}
@@ -71,12 +80,12 @@ jobs:
           popd
 
       - name: Extract metadata for Docker
-        if: inputs.scan_type == 'image'
+        if: inputs.scan_type == 'image' && inputs.image_ref == ''
         id: meta
         run: echo "tags=${{ steps.package.outputs.jar_version }}-${{ steps.package.outputs.git_commit }}" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
-        if: inputs.scan_type == 'image'
+        if: inputs.scan_type == 'image' && inputs.image_ref == ''
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{inputs.working_dir}}
@@ -93,7 +102,8 @@ jobs:
           scan_severity: ${{ inputs.vulnerability_severity }}
           failure_severity: ${{ inputs.vulnerability_severity }}
           publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
-          image_ref: ${{ steps.meta.outputs.tags }}
+          # Scan the explicitly-supplied published image when given; otherwise the locally-built one.
+          image_ref: ${{ inputs.image_ref != '' && inputs.image_ref || steps.meta.outputs.tags }}
           scan_type: ${{ inputs.scan_type }}
         continue-on-error: true
 


### PR DESCRIPTION
## What

Adds an optional `image_ref` input to `shared-vulnerability-scan-failure-notify.yaml`. When set, the workflow **skips** the JDK / `mvn package` / `docker build` steps and scans that already-published image reference directly. When empty (the default), behaviour is **unchanged**.

## Why

The scheduled notify workflow had two modes:
- `fs` — scans repo files (npm/maven manifests). Blind to the contents of a base image (e.g. the Java JARs inside a Keycloak base image).
- `image` — `mvn package` → `docker build` of a single default `Dockerfile` → scan the freshly-built image. Assumes a Maven project with one Dockerfile, and only ever scans a *just-built* image.

Neither can **re-scan an already-released image over time** for CVEs disclosed *after* it was built. That's the gap behind UID2-7390 (the Self-Serve Portal's published Keycloak image accumulated 14 HIGH auth CVEs — incl. CVE-2026-4282 — that no scheduled scan ever surfaced, because the portal is a Node app with three differently-named Dockerfiles and runs the notify in `fs` mode).

## How it stays backward-compatible

`image_ref` defaults to `''`. The four build-from-source steps are now gated on `inputs.scan_type == 'image' && inputs.image_ref == ''`, and the scan step resolves `image_ref` to the supplied value or the locally-built tag:

```yaml
image_ref: ${{ inputs.image_ref != '' && inputs.image_ref || steps.meta.outputs.tags }}
```

The 7 repos that currently call this workflow in image mode (`uid2-admin`, `uid2-core`, `uid2-e2e`, `uid2-operator`, `uid2-optout`, `uid2-snowflake`, `uid2-validator`) pass **no** `image_ref`, so they run the exact same build-from-source path as today. No changes required in those repos.

## Notes

- The supplied image must be pullable without auth, or the caller must log in to the registry before invoking the workflow (documented in the input description). The first consumer (uid2-self-serve-portal, public GHCR images) needs no login.
- Trivy action remains SHA-pinned (unchanged) — no floating tags, per the recent trivy-action supply-chain compromise.
- Also unblocks UID2-7353 (recurring scan of pinned EKS addon images).

## Consumer PR

uid2-self-serve-portal will call this with `scan_type: image` + `image_ref` for its three published images (separate PR). Requires `v3` to be re-tagged to this commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)