### PR TITLE
UID2-7390: support building a specific Dockerfile in the vuln-scan notify workflow

### DIFF
--- a/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
@@ -30,6 +30,13 @@ on:
         description: The path to the pom.xml and Dockerfile.
         type: string
         default: '.'
+      dockerfile:
+        description: >-
+          For image scans of non-Maven repos: path to a Dockerfile to build and scan directly.
+          When set, the JDK/Maven build steps are skipped and this Dockerfile is built (re-pulling
+          its base image) and scanned. When empty (the default), image mode builds via Maven as before.
+        type: string
+        default: ''
     secrets:
       SLACK_WEBHOOK:
         required: false
@@ -50,14 +57,14 @@ jobs:
           path: uid2-shared-actions
 
       - name: Set up JDK
-        if: inputs.scan_type == 'image'
+        if: inputs.scan_type == 'image' && inputs.dockerfile == ''
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java_version }}
 
       - name: Package JAR
-        if: inputs.scan_type == 'image'
+        if: inputs.scan_type == 'image' && inputs.dockerfile == ''
         id: package
         run: |
           pushd ${{ inputs.working_dir }}
@@ -71,12 +78,12 @@ jobs:
           popd
 
       - name: Extract metadata for Docker
-        if: inputs.scan_type == 'image'
+        if: inputs.scan_type == 'image' && inputs.dockerfile == ''
         id: meta
         run: echo "tags=${{ steps.package.outputs.jar_version }}-${{ steps.package.outputs.git_commit }}" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
-        if: inputs.scan_type == 'image'
+        if: inputs.scan_type == 'image' && inputs.dockerfile == ''
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{inputs.working_dir}}
@@ -86,6 +93,16 @@ jobs:
             JAR_VERSION=${{ steps.package.outputs.jar_version }}
             IMAGE_VERSION=${{ steps.package.outputs.jar_version }}-${{ steps.package.outputs.git_commit }}
 
+      # Non-Maven path: build the supplied Dockerfile directly (re-pulls its base image each run).
+      - name: Build Docker image from Dockerfile
+        if: inputs.scan_type == 'image' && inputs.dockerfile != ''
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ${{ inputs.working_dir }}
+          file: ${{ inputs.dockerfile }}
+          load: true
+          tags: image-scan:${{ github.sha }}
+
       - name: Vulnerability Scan
         id: vulnerability-scan
         uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
@@ -93,7 +110,7 @@ jobs:
           scan_severity: ${{ inputs.vulnerability_severity }}
           failure_severity: ${{ inputs.vulnerability_severity }}
           publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
-          image_ref: ${{ steps.meta.outputs.tags }}
+          image_ref: ${{ inputs.dockerfile != '' && format('image-scan:{0}', github.sha) || steps.meta.outputs.tags }}
           scan_type: ${{ inputs.scan_type }}
         continue-on-error: true
 


### PR DESCRIPTION
## What

Adds an optional `dockerfile` input to `shared-vulnerability-scan-failure-notify.yaml`. When set, image mode **skips the JDK/Maven build** and instead `docker build`s the supplied Dockerfile directly (re-pulling its base image), then runs the **existing** scan + Slack-notify + fail steps. When empty (the default), image mode builds via Maven exactly as today.

## Why

Image mode was hardwired to a Maven build (`mvn package` → build the default `Dockerfile` → scan → notify). Non-Maven repos, or repos with multiple differently-named Dockerfiles (e.g. `uid2-self-serve-portal`'s Keycloak image), couldn't reach the scan + notify tail without copying it. That copy is the duplication this removes: a caller can now schedule a recurring scan of an image it builds with a single matrix entry, and build + scan + notify stay defined **once**, here.

## Backward compatibility

`dockerfile` defaults to `''`. The Maven build steps are gated on `inputs.dockerfile == ''`, and the scan's `image_ref` resolves to the Maven-built tag when `dockerfile` is empty. The repos that call this in image mode today (`uid2-admin`, `uid2-core`, `uid2-e2e`, `uid2-operator`, `uid2-optout`, `uid2-snowflake`, `uid2-validator`) pass no `dockerfile`, so they run the identical Maven path. No changes required in those repos.

## First consumer

`uid2-self-serve-portal` (separate PR) calls this in a matrix to scan its Keycloak image on the existing schedule. Requires `v3` to be re-tagged to this commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)