### PR TITLE
UID2-6767: standardize Docker publish vuln floor to CRITICAL,HIGH + exception-ticket guard

### DIFF
--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -50,7 +50,7 @@ on:
         description: >
           The severity to fail the workflow if such vulnerability is detected. DO NOT
           override it unless a Jira ticket is raised. Must be one of ['CRITICAL',
-          'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM'] (without space in between). (UID2-6767)
+          'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM'] (without space in between).
         type: string
         default: 'CRITICAL,HIGH'
       vulnerability_exception_ticket:

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -56,7 +56,7 @@ on:
       vulnerability_exception_ticket:
         description: >
           Jira ticket link justifying a CRITICAL-only vulnerability_severity (required only
-          when it is 'CRITICAL', i.e. HIGH dropped). Format: https://thetradedesk.atlassian.net/browse/UID2-1234 or EUID-….
+          when it is 'CRITICAL', i.e. HIGH dropped). Format: https://thetradedesk.atlassian.net/browse/UID2-1234.
         type: string
         default: ''
 jobs:

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -46,7 +46,7 @@ on:
         description: If false, skips SLSA build-provenance attestation + verification. Defaults to true.
         type: boolean
         default: true
-      failure_severity:
+      vulnerability_severity:
         description: >
           The severity to fail the workflow if such vulnerability is detected. DO NOT
           override it unless a Jira ticket is raised. Must be EXACTLY one of
@@ -96,7 +96,7 @@ jobs:
           publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
           scan_type: image
           attestation_enabled: ${{ inputs.attestation_enabled }}
-          failure_severity: ${{ inputs.failure_severity }}
+          vulnerability_severity: ${{ inputs.vulnerability_severity }}
           vulnerability_exception_ticket: ${{ inputs.vulnerability_exception_ticket }}
 
       - name: Create Release

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -46,11 +46,12 @@ on:
         description: If false, skips SLSA build-provenance attestation + verification. Defaults to true.
         type: boolean
         default: true
-      vulnerability_severity:
+      failure_severity:
         description: >
           The severity to fail the workflow if such vulnerability is detected. DO NOT
-          override it unless a Jira ticket is raised. Must be one of ['CRITICAL',
-          'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM'] (without space in between).
+          override it unless a Jira ticket is raised. Must be EXACTLY one of
+          ['CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM'] (uppercase, without
+          space in between).
         type: string
         default: 'CRITICAL,HIGH'
       vulnerability_exception_ticket:
@@ -95,7 +96,7 @@ jobs:
           publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
           scan_type: image
           attestation_enabled: ${{ inputs.attestation_enabled }}
-          failure_severity: ${{ inputs.vulnerability_severity }}
+          failure_severity: ${{ inputs.failure_severity }}
           vulnerability_exception_ticket: ${{ inputs.vulnerability_exception_ticket }}
 
       - name: Create Release

--- a/.github/workflows/shared-publish-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-to-docker-versioned.yaml
@@ -46,6 +46,19 @@ on:
         description: If false, skips SLSA build-provenance attestation + verification. Defaults to true.
         type: boolean
         default: true
+      vulnerability_severity:
+        description: >
+          The severity to fail the workflow if such vulnerability is detected. DO NOT
+          override it unless a Jira ticket is raised. Must be one of ['CRITICAL',
+          'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM'] (without space in between). (UID2-6767)
+        type: string
+        default: 'CRITICAL,HIGH'
+      vulnerability_exception_ticket:
+        description: >
+          Jira ticket link justifying a CRITICAL-only vulnerability_severity (required only
+          when it is 'CRITICAL', i.e. HIGH dropped). Format: https://thetradedesk.atlassian.net/browse/UID2-1234 or EUID-….
+        type: string
+        default: ''
 jobs:
   buildImage:
     name: Build Image
@@ -82,6 +95,8 @@ jobs:
           publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
           scan_type: image
           attestation_enabled: ${{ inputs.attestation_enabled }}
+          failure_severity: ${{ inputs.vulnerability_severity }}
+          vulnerability_exception_ticket: ${{ inputs.vulnerability_exception_ticket }}
 
       - name: Create Release
         id: github_release

--- a/.github/workflows/test-scripts.yaml
+++ b/.github/workflows/test-scripts.yaml
@@ -1,0 +1,36 @@
+name: Test Scripts
+
+# Runs the bash unit tests colocated with composite actions (actions/**/tests/*.sh).
+on:
+  push:
+    paths:
+      - 'actions/**/*.sh'
+      - '.github/workflows/test-scripts.yaml'
+  pull_request:
+    paths:
+      - 'actions/**/*.sh'
+      - '.github/workflows/test-scripts.yaml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run script tests
+        run: |
+          shopt -s nullglob globstar
+          tests=(actions/**/tests/*.sh)
+          if [[ ${#tests[@]} -eq 0 ]]; then
+            echo "No tests found under actions/**/tests/"
+            exit 0
+          fi
+          fail=0
+          for t in "${tests[@]}"; do
+            echo "::group::$t"
+            bash "$t" || fail=1
+            echo "::endgroup::"
+          done
+          exit $fail

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -40,7 +40,7 @@ inputs:
       Trivy severities that fail the build and block the push. Must be one of
       'CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM' (no spaces), matching
       the Java publish path. Defaults to CRITICAL,HIGH. DO NOT drop HIGH (i.e. set
-      'CRITICAL') unless a vulnerability_exception_ticket is supplied (UID2-6767).
+      'CRITICAL') unless a vulnerability_exception_ticket is supplied.
     default: CRITICAL,HIGH
   vulnerability_exception_ticket:
     description: >

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -35,6 +35,20 @@ inputs:
   attestation_enabled:
     description: Set to 'false' to skip SLSA build-provenance attestation + verification. Default 'true'.
     default: 'true'
+  failure_severity:
+    description: >
+      Trivy severities that fail the build and block the push. Must be one of
+      'CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM' (no spaces), matching
+      the Java publish path. Defaults to CRITICAL,HIGH. DO NOT drop HIGH (i.e. set
+      'CRITICAL') unless a vulnerability_exception_ticket is supplied (UID2-6767).
+    default: CRITICAL,HIGH
+  vulnerability_exception_ticket:
+    description: >
+      Jira ticket link justifying a CRITICAL-only failure_severity, e.g.
+      https://thetradedesk.atlassian.net/browse/UID2-1234 (UID2 or EUID). Required
+      and format-validated only when failure_severity is 'CRITICAL' (HIGH dropped);
+      the default CRITICAL,HIGH floor ignores it. Format-check only — no live Jira call.
+    default: ''
 
 outputs:
   tags:
@@ -42,9 +56,19 @@ outputs:
     value: ${{ steps.meta.outputs.tags }}
 
 runs:
-  using: "composite" 
+  using: "composite"
 
   steps:
+    # Fail fast (before the build) if this publish drops HIGH from the vuln floor
+    # without a tracked Jira exception. Logic + tests live in the script so it is
+    # unit-testable; inputs go via env, never interpolated into run:.
+    - name: Validate vulnerability floor + exception ticket
+      shell: bash
+      env:
+        FAILURE_SEVERITY: ${{ inputs.failure_severity }}
+        EXCEPTION_TICKET: ${{ inputs.vulnerability_exception_ticket }}
+      run: bash "${{ github.action_path }}/validate_vuln_floor.sh"
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -94,7 +118,7 @@ runs:
       uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
       with:
         publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
-        failure_severity: CRITICAL
+        failure_severity: ${{ inputs.failure_severity }}
         scan_severity: CRITICAL,HIGH
         image_ref: ${{ steps.extractImageTag.outputs.firstTag }}
         scan_type: ${{ inputs.scan_type }}

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -35,7 +35,7 @@ inputs:
   attestation_enabled:
     description: Set to 'false' to skip SLSA build-provenance attestation + verification. Default 'true'.
     default: 'true'
-  failure_severity:
+  vulnerability_severity:
     description: >
       Trivy severities that fail the build and block the push. Must be EXACTLY one
       of 'CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM' (uppercase, no
@@ -47,9 +47,9 @@ inputs:
     default: CRITICAL,HIGH
   vulnerability_exception_ticket:
     description: >
-      Jira ticket link justifying a CRITICAL-only failure_severity, e.g.
+      Jira ticket link justifying a CRITICAL-only vulnerability_severity, e.g.
       https://thetradedesk.atlassian.net/browse/UID2-1234. Required
-      and format-validated only when failure_severity is 'CRITICAL' (HIGH dropped);
+      and format-validated only when vulnerability_severity is 'CRITICAL' (HIGH dropped);
       the default CRITICAL,HIGH floor ignores it. Format-check only — no live Jira call.
     default: ''
 
@@ -69,7 +69,7 @@ runs:
       id: vulnFloor
       shell: bash
       env:
-        FAILURE_SEVERITY: ${{ inputs.failure_severity }}
+        FAILURE_SEVERITY: ${{ inputs.vulnerability_severity }}
         EXCEPTION_TICKET: ${{ inputs.vulnerability_exception_ticket }}
       run: bash "${{ github.action_path }}/validate_vuln_floor.sh"
 

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -45,7 +45,7 @@ inputs:
   vulnerability_exception_ticket:
     description: >
       Jira ticket link justifying a CRITICAL-only failure_severity, e.g.
-      https://thetradedesk.atlassian.net/browse/UID2-1234 (UID2 or EUID). Required
+      https://thetradedesk.atlassian.net/browse/UID2-1234. Required
       and format-validated only when failure_severity is 'CRITICAL' (HIGH dropped);
       the default CRITICAL,HIGH floor ignores it. Format-check only — no live Jira call.
     default: ''

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -37,10 +37,13 @@ inputs:
     default: 'true'
   failure_severity:
     description: >
-      Trivy severities that fail the build and block the push. Must be one of
-      'CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM' (no spaces), matching
-      the Java publish path. Defaults to CRITICAL,HIGH. DO NOT drop HIGH (i.e. set
-      'CRITICAL') unless a vulnerability_exception_ticket is supplied.
+      Trivy severities that fail the build and block the push. Must be EXACTLY one
+      of 'CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM' (uppercase, no
+      spaces), matching the Java publish path — any other value is rejected before
+      the build. The SARIF report floor is auto-widened to a superset so anything
+      that can fail the build is also reported. Defaults to CRITICAL,HIGH. DO NOT
+      drop HIGH (i.e. set 'CRITICAL') unless a vulnerability_exception_ticket is
+      supplied.
     default: CRITICAL,HIGH
   vulnerability_exception_ticket:
     description: >
@@ -63,6 +66,7 @@ runs:
     # without a tracked Jira exception. Logic + tests live in the script so it is
     # unit-testable; inputs go via env, never interpolated into run:.
     - name: Validate vulnerability floor + exception ticket
+      id: vulnFloor
       shell: bash
       env:
         FAILURE_SEVERITY: ${{ inputs.failure_severity }}
@@ -118,8 +122,8 @@ runs:
       uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
       with:
         publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
-        failure_severity: ${{ inputs.failure_severity }}
-        scan_severity: CRITICAL,HIGH
+        failure_severity: ${{ steps.vulnFloor.outputs.failure_severity }}
+        scan_severity: ${{ steps.vulnFloor.outputs.scan_severity }}
         image_ref: ${{ steps.extractImageTag.outputs.firstTag }}
         scan_type: ${{ inputs.scan_type }}
 

--- a/actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
@@ -35,9 +35,6 @@ assert_contains "CRITICAL+ticket: notice"    "::notice::" "$OUTPUT"
 assert_contains "CRITICAL+ticket: audit summary" "Vulnerability floor exception" "$(cat "$SUMMARY")"
 assert_contains "CRITICAL+ticket: ticket in summary" "UID2-6767" "$(cat "$SUMMARY")"
 
-run "CRITICAL" "https://thetradedesk.atlassian.net/browse/EUID-123"
-assert_eq       "CRITICAL+EUID ticket: block (only UID2 accepted)" "1" "$RC"
-
 run "CRITICAL" ""
 assert_eq       "CRITICAL no ticket: block"  "1" "$RC"
 assert_contains "CRITICAL no ticket: msg"    "no vulnerability_exception_ticket was supplied" "$OUTPUT"

--- a/actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
@@ -12,21 +12,30 @@ assert_contains() { # $1=desc $2=needle $3=haystack
 }
 
 # Runs the guard with FAILURE_SEVERITY=$1, EXCEPTION_TICKET=$2; captures combined
-# output in $OUTPUT, exit code in $RC, and the job-summary file in $SUMMARY.
+# output in $OUTPUT, exit code in $RC, the job-summary file in $SUMMARY, and the
+# emitted step outputs (failure_severity=/scan_severity=) in $OUTPUTS.
 run() {
-  SUMMARY="$(mktemp)"
-  OUTPUT="$(FAILURE_SEVERITY="${1-}" EXCEPTION_TICKET="${2-}" GITHUB_STEP_SUMMARY="$SUMMARY" bash "$SCRIPT" 2>&1)"; RC=$?
+  SUMMARY="$(mktemp)"; OUTFILE="$(mktemp)"
+  OUTPUT="$(FAILURE_SEVERITY="${1-}" EXCEPTION_TICKET="${2-}" GITHUB_STEP_SUMMARY="$SUMMARY" GITHUB_OUTPUT="$OUTFILE" bash "$SCRIPT" 2>&1)"; RC=$?
+  OUTPUTS="$(cat "$OUTFILE")"
 }
 
-# --- Standard floors: pass, no ticket needed ---
+# --- Standard floors: pass, no ticket needed; scan_severity == failure_severity ---
 run "CRITICAL,HIGH" ""
 assert_eq       "CRITICAL,HIGH: pass"        "0" "$RC"
+assert_contains "CRITICAL,HIGH: failure out" "failure_severity=CRITICAL,HIGH" "$OUTPUTS"
+assert_contains "CRITICAL,HIGH: scan out"    "scan_severity=CRITICAL,HIGH" "$OUTPUTS"
 run "CRITICAL,HIGH,MEDIUM" ""
 assert_eq       "CRITICAL,HIGH,MEDIUM: pass" "0" "$RC"
+assert_contains "CRITICAL,HIGH,MEDIUM: scan out" "scan_severity=CRITICAL,HIGH,MEDIUM" "$OUTPUTS"
+
+# --- Non-exact tokens Trivy would reject: block here, don't pass them on ---
 run "critical,high" ""
-assert_eq       "lowercase: pass"            "0" "$RC"
+assert_eq       "lowercase: block"           "1" "$RC"
+assert_contains "lowercase: invalid msg"     "Invalid vulnerability severity floor" "$OUTPUT"
 run "CRITICAL, HIGH" ""
-assert_eq       "spaced: pass"               "0" "$RC"
+assert_eq       "spaced: block"              "1" "$RC"
+assert_contains "spaced: invalid msg"        "Invalid vulnerability severity floor" "$OUTPUT"
 
 # --- CRITICAL-only: needs a valid ticket ---
 run "CRITICAL" "https://thetradedesk.atlassian.net/browse/UID2-6767"
@@ -34,6 +43,8 @@ assert_eq       "CRITICAL+UID2 ticket: pass" "0" "$RC"
 assert_contains "CRITICAL+ticket: notice"    "::notice::" "$OUTPUT"
 assert_contains "CRITICAL+ticket: audit summary" "Vulnerability floor exception" "$(cat "$SUMMARY")"
 assert_contains "CRITICAL+ticket: ticket in summary" "UID2-6767" "$(cat "$SUMMARY")"
+assert_contains "CRITICAL+ticket: failure out" "failure_severity=CRITICAL" "$OUTPUTS"
+assert_contains "CRITICAL+ticket: scan widened to HIGH" "scan_severity=CRITICAL,HIGH" "$OUTPUTS"
 
 run "CRITICAL" ""
 assert_eq       "CRITICAL no ticket: block"  "1" "$RC"

--- a/actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
@@ -36,7 +36,7 @@ assert_contains "CRITICAL+ticket: audit summary" "Vulnerability floor exception"
 assert_contains "CRITICAL+ticket: ticket in summary" "UID2-6767" "$(cat "$SUMMARY")"
 
 run "CRITICAL" "https://thetradedesk.atlassian.net/browse/EUID-123"
-assert_eq       "CRITICAL+EUID ticket: pass" "0" "$RC"
+assert_eq       "CRITICAL+EUID ticket: block (only UID2 accepted)" "1" "$RC"
 
 run "CRITICAL" ""
 assert_eq       "CRITICAL no ticket: block"  "1" "$RC"

--- a/actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Tests for validate_vuln_floor.sh — run: bash actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh
+set -uo pipefail
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/validate_vuln_floor.sh"
+fail=0
+
+assert_eq() { # $1=desc $2=expected $3=actual
+  if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected '$2' got '$3'"; fail=1; fi
+}
+assert_contains() { # $1=desc $2=needle $3=haystack
+  if [[ "$3" == *"$2"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: '$3' missing '$2'"; fail=1; fi
+}
+
+# Runs the guard with FAILURE_SEVERITY=$1, EXCEPTION_TICKET=$2; captures combined
+# output in $OUTPUT, exit code in $RC, and the job-summary file in $SUMMARY.
+run() {
+  SUMMARY="$(mktemp)"
+  OUTPUT="$(FAILURE_SEVERITY="${1-}" EXCEPTION_TICKET="${2-}" GITHUB_STEP_SUMMARY="$SUMMARY" bash "$SCRIPT" 2>&1)"; RC=$?
+}
+
+# --- Standard floors: pass, no ticket needed ---
+run "CRITICAL,HIGH" ""
+assert_eq       "CRITICAL,HIGH: pass"        "0" "$RC"
+run "CRITICAL,HIGH,MEDIUM" ""
+assert_eq       "CRITICAL,HIGH,MEDIUM: pass" "0" "$RC"
+run "critical,high" ""
+assert_eq       "lowercase: pass"            "0" "$RC"
+run "CRITICAL, HIGH" ""
+assert_eq       "spaced: pass"               "0" "$RC"
+
+# --- CRITICAL-only: needs a valid ticket ---
+run "CRITICAL" "https://thetradedesk.atlassian.net/browse/UID2-6767"
+assert_eq       "CRITICAL+UID2 ticket: pass" "0" "$RC"
+assert_contains "CRITICAL+ticket: notice"    "::notice::" "$OUTPUT"
+assert_contains "CRITICAL+ticket: audit summary" "Vulnerability floor exception" "$(cat "$SUMMARY")"
+assert_contains "CRITICAL+ticket: ticket in summary" "UID2-6767" "$(cat "$SUMMARY")"
+
+run "CRITICAL" "https://thetradedesk.atlassian.net/browse/EUID-123"
+assert_eq       "CRITICAL+EUID ticket: pass" "0" "$RC"
+
+run "CRITICAL" ""
+assert_eq       "CRITICAL no ticket: block"  "1" "$RC"
+assert_contains "CRITICAL no ticket: msg"    "no vulnerability_exception_ticket was supplied" "$OUTPUT"
+
+run "CRITICAL" "https://evil.com/UID2-1"
+assert_eq       "CRITICAL bad host: block"   "1" "$RC"
+assert_contains "CRITICAL bad host: msg"     "malformed" "$OUTPUT"
+
+run "CRITICAL" "https://thetradedesk.atlassian.net/browse/JIRA-1"
+assert_eq       "CRITICAL wrong project: block" "1" "$RC"
+
+run "CRITICAL" $'https://thetradedesk.atlassian.net/browse/UID2-1\n::set-output name=x::y'
+assert_eq       "CRITICAL newline ticket: block" "1" "$RC"
+assert_contains "CRITICAL newline: msg"      "single-line" "$OUTPUT"
+
+# --- Invalid floors: reject rather than pass to Trivy ---
+run "HIGH" ""
+assert_eq       "HIGH-only (drops CRITICAL): block" "1" "$RC"
+assert_contains "HIGH-only: invalid msg"     "Invalid vulnerability severity floor" "$OUTPUT"
+run "" ""
+assert_eq       "empty floor: block"         "1" "$RC"
+run "FOO,BAR" ""
+assert_eq       "garbage floor: block"       "1" "$RC"
+
+exit $fail

--- a/actions/shared_publish_to_docker/validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/validate_vuln_floor.sh
@@ -40,13 +40,13 @@ if [[ "$ticket" == *$'\n'* ]]; then
   exit 1
 fi
 
-ticket_re='^https://thetradedesk\.atlassian\.net/browse/(UID2|EUID)-[0-9]+$'
+ticket_re='^https://thetradedesk\.atlassian\.net/browse/UID2-[0-9]+$'
 if [[ ! "$ticket" =~ $ticket_re ]]; then
   if [[ -z "$ticket" ]]; then
-    echo "::error::Vulnerability floor 'CRITICAL' drops HIGH but no vulnerability_exception_ticket was supplied. Provide a Jira link (https://thetradedesk.atlassian.net/browse/UID2-1234, UID2 or EUID) or raise the floor to CRITICAL,HIGH."
+    echo "::error::Vulnerability floor 'CRITICAL' drops HIGH but no vulnerability_exception_ticket was supplied. Provide a Jira link (https://thetradedesk.atlassian.net/browse/UID2-1234) or raise the floor to CRITICAL,HIGH."
   else
     # Single-line (newline already rejected) — cannot start a workflow command mid-line.
-    echo "::error::vulnerability_exception_ticket '${ticket}' is malformed. Expected https://thetradedesk.atlassian.net/browse/UID2-1234 (UID2 or EUID)."
+    echo "::error::vulnerability_exception_ticket '${ticket}' is malformed. Expected https://thetradedesk.atlassian.net/browse/UID2-1234."
   fi
   exit 1
 fi

--- a/actions/shared_publish_to_docker/validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/validate_vuln_floor.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Validates the Docker publish vulnerability-scan floor and its exception-ticket
+# policy (UID2-6767), before any build/push so a misconfigured floor fails fast.
+#
+# Env:
+#   FAILURE_SEVERITY  - Trivy failure floor. Must be one of the allowlist below.
+#   EXCEPTION_TICKET  - Jira link justifying a CRITICAL-only floor (HIGH dropped).
+#
+# Exit 0 = allowed; exit 1 = blocked. Format-check only — no live Jira call, so
+# no token dependency. A CRITICAL-only floor waives HIGH gating, so it is recorded
+# to the job summary + a ::notice:: as durable SOC2 change-testing evidence.
+set -euo pipefail
+
+# Normalize: strip ALL whitespace and uppercase. Trivy severities are uppercase;
+# the allowlist mirrors the Java publish path's documented set.
+norm="$(printf '%s' "${FAILURE_SEVERITY:-}" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
+
+case "$norm" in
+  CRITICAL,HIGH|CRITICAL,HIGH,MEDIUM)
+    echo "Vulnerability floor '${norm}' includes HIGH — no exception ticket required."
+    exit 0
+    ;;
+  CRITICAL)
+    : # HIGH dropped — falls through to the exception-ticket requirement below.
+    ;;
+  *)
+    # Reject empty/unknown/mis-ordered floors rather than passing them to Trivy.
+    # $norm is whitespace-stripped, so it is safe to echo on one line.
+    echo "::error::Invalid vulnerability severity floor '${norm}'. Must be one of: CRITICAL, CRITICAL,HIGH, CRITICAL,HIGH,MEDIUM (no spaces)."
+    exit 1
+    ;;
+esac
+
+# CRITICAL-only floor: require a format-valid Jira exception ticket. Reject a
+# multi-line value first so the anchored regex can't be defeated and no attacker-
+# controlled newline can inject a GitHub workflow command into the log.
+ticket="${EXCEPTION_TICKET:-}"
+if [[ "$ticket" == *$'\n'* ]]; then
+  echo "::error::vulnerability_exception_ticket must be a single-line Jira URL."
+  exit 1
+fi
+
+ticket_re='^https://thetradedesk\.atlassian\.net/browse/(UID2|EUID)-[0-9]+$'
+if [[ ! "$ticket" =~ $ticket_re ]]; then
+  if [[ -z "$ticket" ]]; then
+    echo "::error::Vulnerability floor 'CRITICAL' drops HIGH but no vulnerability_exception_ticket was supplied. Provide a Jira link (https://thetradedesk.atlassian.net/browse/UID2-1234, UID2 or EUID) or raise the floor to CRITICAL,HIGH."
+  else
+    # Single-line (newline already rejected) — cannot start a workflow command mid-line.
+    echo "::error::vulnerability_exception_ticket '${ticket}' is malformed. Expected https://thetradedesk.atlassian.net/browse/UID2-1234 (UID2 or EUID)."
+  fi
+  exit 1
+fi
+
+# Allowed exception — leave a durable audit trail (SOC2 rows 8/9).
+echo "::notice::Vulnerability floor 'CRITICAL' (HIGH gating waived) justified by exception ticket ${ticket}."
+{
+  echo "### ⚠️ Vulnerability floor exception (UID2-6767)"
+  echo ""
+  echo "- Failure floor: \`CRITICAL\` — HIGH severity gating **waived**"
+  echo "- Exception ticket: ${ticket}"
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/actions/shared_publish_to_docker/validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/validate_vuln_floor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Validates the Docker publish vulnerability-scan floor and its exception-ticket
-# policy (UID2-6767), before any build/push so a misconfigured floor fails fast.
+# policy, before any build/push so a misconfigured floor fails fast.
 #
 # Env:
 #   FAILURE_SEVERITY  - Trivy failure floor. Must be one of the allowlist below.
@@ -54,7 +54,7 @@ fi
 # Allowed exception — leave a durable audit trail (SOC2 rows 8/9).
 echo "::notice::Vulnerability floor 'CRITICAL' (HIGH gating waived) justified by exception ticket ${ticket}."
 {
-  echo "### ⚠️ Vulnerability floor exception (UID2-6767)"
+  echo "### ⚠️ Vulnerability floor exception"
   echo ""
   echo "- Failure floor: \`CRITICAL\` — HIGH severity gating **waived**"
   echo "- Exception ticket: ${ticket}"

--- a/actions/shared_publish_to_docker/validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/validate_vuln_floor.sh
@@ -3,59 +3,82 @@
 # policy, before any build/push so a misconfigured floor fails fast.
 #
 # Env:
-#   FAILURE_SEVERITY  - Trivy failure floor. Must be one of the allowlist below.
+#   FAILURE_SEVERITY  - Trivy failure floor. Must be EXACTLY one of the allowlist
+#                       below. Trivy matches severities case-sensitively with no
+#                       whitespace trimming, so we do NOT normalise: a lowercase,
+#                       spaced or mis-ordered value is rejected here rather than
+#                       passed on to fail the scan later with an opaque error.
 #   EXCEPTION_TICKET  - Jira link justifying a CRITICAL-only floor (HIGH dropped).
+#
+# Outputs (GITHUB_OUTPUT):
+#   failure_severity  - the validated failure floor, echoed back for the scan step
+#                       so the value that gates Trivy is exactly the value checked.
+#   scan_severity     - the report floor, always a superset of failure_severity so
+#                       anything that can fail the build also appears in the
+#                       uploaded SARIF report.
 #
 # Exit 0 = allowed; exit 1 = blocked. Format-check only — no live Jira call, so
 # no token dependency. A CRITICAL-only floor waives HIGH gating, so it is recorded
 # to the job summary + a ::notice:: as a durable audit trail.
 set -euo pipefail
 
-# Normalize: strip ALL whitespace and uppercase. Trivy severities are uppercase;
-# the allowlist mirrors the Java publish path's documented set.
-norm="$(printf '%s' "${FAILURE_SEVERITY:-}" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
+failure_severity="${FAILURE_SEVERITY:-}"
 
-case "$norm" in
+# Exact-match only against the Trivy-valid, canonically-ordered floors. Each maps
+# to a scan (report) severity that is a superset of the failure floor.
+case "$failure_severity" in
   CRITICAL,HIGH|CRITICAL,HIGH,MEDIUM)
-    echo "Vulnerability floor '${norm}' includes HIGH — no exception ticket required."
-    exit 0
+    scan_severity="$failure_severity"
+    echo "Vulnerability floor '${failure_severity}' includes HIGH — no exception ticket required."
     ;;
   CRITICAL)
-    : # HIGH dropped — falls through to the exception-ticket requirement below.
+    # HIGH dropped from the failure floor: still scan+report HIGH, and require a
+    # tracked Jira exception ticket (validated below).
+    scan_severity="CRITICAL,HIGH"
     ;;
   *)
-    # Reject empty/unknown/mis-ordered floors rather than passing them to Trivy.
-    # $norm is whitespace-stripped, so it is safe to echo on one line.
-    echo "::error::Invalid vulnerability severity floor '${norm}'. Must be one of: CRITICAL, CRITICAL,HIGH, CRITICAL,HIGH,MEDIUM (no spaces)."
+    # Reject empty/unknown/lowercase/spaced/mis-ordered floors rather than passing
+    # them to Trivy. Strip control chars from the echoed value so a crafted input
+    # cannot inject a GitHub workflow command into the log.
+    safe="$(printf '%s' "$failure_severity" | tr -d '[:cntrl:]')"
+    echo "::error::Invalid vulnerability severity floor '${safe}'. Must be EXACTLY one of: CRITICAL, CRITICAL,HIGH, CRITICAL,HIGH,MEDIUM (uppercase, no spaces)."
     exit 1
     ;;
 esac
 
-# CRITICAL-only floor: require a format-valid Jira exception ticket. Reject a
-# multi-line value first so the anchored regex can't be defeated and no attacker-
-# controlled newline can inject a GitHub workflow command into the log.
-ticket="${EXCEPTION_TICKET:-}"
-if [[ "$ticket" == *$'\n'* ]]; then
-  echo "::error::vulnerability_exception_ticket must be a single-line Jira URL."
-  exit 1
-fi
-
-ticket_re='^https://thetradedesk\.atlassian\.net/browse/UID2-[0-9]+$'
-if [[ ! "$ticket" =~ $ticket_re ]]; then
-  if [[ -z "$ticket" ]]; then
-    echo "::error::Vulnerability floor 'CRITICAL' drops HIGH but no vulnerability_exception_ticket was supplied. Provide a Jira link (https://thetradedesk.atlassian.net/browse/UID2-1234) or raise the floor to CRITICAL,HIGH."
-  else
-    # Single-line (newline already rejected) — cannot start a workflow command mid-line.
-    echo "::error::vulnerability_exception_ticket '${ticket}' is malformed. Expected https://thetradedesk.atlassian.net/browse/UID2-1234."
+if [[ "$failure_severity" == CRITICAL ]]; then
+  # Require a format-valid Jira exception ticket. Reject a multi-line value first
+  # so the anchored regex can't be defeated and no attacker-controlled newline can
+  # inject a GitHub workflow command into the log.
+  ticket="${EXCEPTION_TICKET:-}"
+  if [[ "$ticket" == *$'\n'* ]]; then
+    echo "::error::vulnerability_exception_ticket must be a single-line Jira URL."
+    exit 1
   fi
-  exit 1
+
+  ticket_re='^https://thetradedesk\.atlassian\.net/browse/UID2-[0-9]+$'
+  if [[ ! "$ticket" =~ $ticket_re ]]; then
+    if [[ -z "$ticket" ]]; then
+      echo "::error::Vulnerability floor 'CRITICAL' drops HIGH but no vulnerability_exception_ticket was supplied. Provide a Jira link (https://thetradedesk.atlassian.net/browse/UID2-1234) or raise the floor to CRITICAL,HIGH."
+    else
+      # Single-line (newline already rejected) — cannot start a workflow command mid-line.
+      echo "::error::vulnerability_exception_ticket '${ticket}' is malformed. Expected https://thetradedesk.atlassian.net/browse/UID2-1234."
+    fi
+    exit 1
+  fi
+
+  # Allowed exception — leave a durable audit trail.
+  echo "::notice::Vulnerability floor 'CRITICAL' (HIGH gating waived) justified by exception ticket ${ticket}."
+  {
+    echo "### ⚠️ Vulnerability floor exception"
+    echo ""
+    echo "- Failure floor: \`CRITICAL\` — HIGH severity gating **waived**"
+    echo "- Exception ticket: ${ticket}"
+  } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
 fi
 
-# Allowed exception — leave a durable audit trail.
-echo "::notice::Vulnerability floor 'CRITICAL' (HIGH gating waived) justified by exception ticket ${ticket}."
+# Emit the validated floors for the scan step to consume.
 {
-  echo "### ⚠️ Vulnerability floor exception"
-  echo ""
-  echo "- Failure floor: \`CRITICAL\` — HIGH severity gating **waived**"
-  echo "- Exception ticket: ${ticket}"
-} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  echo "failure_severity=${failure_severity}"
+  echo "scan_severity=${scan_severity}"
+} >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/actions/shared_publish_to_docker/validate_vuln_floor.sh
+++ b/actions/shared_publish_to_docker/validate_vuln_floor.sh
@@ -8,7 +8,7 @@
 #
 # Exit 0 = allowed; exit 1 = blocked. Format-check only — no live Jira call, so
 # no token dependency. A CRITICAL-only floor waives HIGH gating, so it is recorded
-# to the job summary + a ::notice:: as durable SOC2 change-testing evidence.
+# to the job summary + a ::notice:: as a durable audit trail.
 set -euo pipefail
 
 # Normalize: strip ALL whitespace and uppercase. Trivy severities are uppercase;
@@ -51,7 +51,7 @@ if [[ ! "$ticket" =~ $ticket_re ]]; then
   exit 1
 fi
 
-# Allowed exception — leave a durable audit trail (SOC2 rows 8/9).
+# Allowed exception — leave a durable audit trail.
 echo "::notice::Vulnerability floor 'CRITICAL' (HIGH gating waived) justified by exception ticket ${ticket}."
 {
   echo "### ⚠️ Vulnerability floor exception"


### PR DESCRIPTION
## What

Part of [UID2-6767](https://thetradedesk.atlassian.net/browse/UID2-6767) (§4.3, build-time half). Standardizes the **Docker composite publish path**'s Trivy failure-severity floor and enforces the vuln-exception policy the Java path only documents.

- The docker path hardcoded `failure_severity: CRITICAL`, so docker-path images (`uid2-snowflake-monitoring`, `uid2-databricks-monitoring`, `uid2-ssportal-migration`, `uid2-tcportal`, `euid-tcportal`, `uid-reverse-proxy`, `uid2-ssportal-keycloak`) were gated only at **CRITICAL** — a HIGH CVE would not block their release. The Java path already gates at `CRITICAL,HIGH`.
- **`shared-publish-to-docker-versioned.yaml`**: adds a `failure_severity` input (default `CRITICAL,HIGH`), named to match the composite action's input and the existing `scan_severity`/`failure_severity` convention, passed straight through to the composite.
- **`shared_publish_to_docker`**: adds `failure_severity` (default `CRITICAL,HIGH`) + `vulnerability_exception_ticket` inputs and a **fail-fast guard step** (before the build) that:
  - **exact-matches** the floor against the allowlist `{CRITICAL, CRITICAL,HIGH, CRITICAL,HIGH,MEDIUM}` — no normalization. Empty/unknown/HIGH-only *and* lowercase/spaced/mis-ordered values are rejected here. (Trivy matches `--severity` case-sensitively with no whitespace trimming, so a value the guard "normalized" through would otherwise fail the scan later with an opaque error; rejecting early keeps the fail-fast promise.)
  - requires a **format-valid Jira link** (`UID2-XXXX`) only when the floor is CRITICAL-only (HIGH dropped);
  - records a waived (CRITICAL-only) floor to the job summary + a `::notice::` as **SOC2 change-testing evidence**;
  - Format-check only — no live Jira call, no token dependency.
- **Scan report ⊇ failure floor**: the guard emits the validated `failure_severity` plus a `scan_severity` that is always a superset of it (`CRITICAL`→`CRITICAL,HIGH`; the HIGH/MEDIUM floors pass through). The scan step consumes both `steps.vulnFloor.outputs.*`, so the value that gates Trivy is exactly the value validated, and anything that can fail the build (e.g. a MEDIUM under a `CRITICAL,HIGH,MEDIUM` floor) is also present in the uploaded SARIF report — not silently absent.
- Guard logic extracted to `validate_vuln_floor.sh` (run via `github.action_path`) with a unit test and a `test-scripts.yaml` workflow.

## Testing

- **Unit test** — `bash actions/shared_publish_to_docker/tests/test_validate_vuln_floor.sh` — 26/26 assertions pass: valid floors + their emitted `failure_severity`/`scan_severity` outputs, CRITICAL-only scan widened to `CRITICAL,HIGH`, CRITICAL + valid/malformed/missing/newline ticket, lowercase/spaced/HIGH-only/empty/garbage rejection, audit-summary emission.
- **End-to-end smoke test** — drove the real `workflow input → guard → step outputs → Trivy severity` path for representative inputs, validating the derived floors against **Trivy 0.72.0**:
  - `CRITICAL,HIGH` and `CRITICAL,HIGH,MEDIUM` → guard allows; `scan_severity` == floor; Trivy accepts both `--severity` values.
  - `CRITICAL` + valid ticket → guard allows; `scan_severity` widened to `CRITICAL,HIGH`; Trivy accepts both; audit trail written to the job summary.
  - `CRITICAL` with no ticket → blocked before build (exit 1).
  - `critical,high` and `CRITICAL, HIGH` → **blocked before build** by the guard, and confirmed that **Trivy itself rejects those exact strings** (`invalid argument … for "--severity"`) — proving the early block prevents a late, opaque scan failure.
- YAML + `bash -n` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
