### PR TITLE
UID2-7400: make CI release commits satisfy the require_jira_key ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ When adding a new publish workflow, call `IABTechLab/uid2-shared-actions/actions
 
 In-scope UID2/EUID repos enforce a GitHub `commit_message_pattern` ruleset (`require_jira_key`, UID2-7312) on the default branch: every commit must contain a `UID2-<n>` key or a reasoned opt-out `[no-jira - reason: <reason>]`. The ruleset has **no bypass actors**, so the release service account is subject to it like any human author.
 
-The automated release / version-bump commits produced by `actions/commit_pr_and_merge` (`[CI Pipeline] Released <type> version: X.Y.Z`) carry no Jira key, so the action appends a reasoned opt-out marker — `[no-jira - reason: automated release]` — to keep the merge recorded in history (the `uid2-github-alerts` archiver captures it) rather than granting a silent bypass (UID2-7400). Override the reason per call via the `no_jira_reason` input; it must be non-empty.
+The automated release / version-bump commits produced by `actions/commit_pr_and_merge` (`[CI Pipeline] Released <type> version: X.Y.Z`) carry no Jira key, so the action appends a reasoned opt-out marker — `[no-jira - reason: automated release v1.2.3]` — to keep the merge recorded in history (the `uid2-github-alerts` archiver captures it) rather than granting a silent bypass (UID2-7400). The release `tag` (when set) is woven into the reason so each marker is self-describing; override the reason per call via the `no_jira_reason` input (must be non-empty). The composed message is asserted against the ruleset regex at compose time, so a format drift fails the release run early rather than only at merge.
 
 The marker is applied in **two** places because the ruleset evaluates *every* commit a push introduces to the default branch, not just one:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ For pre-release (`prerelease: 'true'`) cuts the changelog's `fromTag` is resolve
 
 When adding a new publish workflow, call `IABTechLab/uid2-shared-actions/actions/shared_create_releases@v3` rather than inlining mikepenz. Do not set `continue-on-error: true` on it — the workflow must fail if release-notes generation fails. Decision documented in [UID2-6762](https://thetradedesk.atlassian.net/browse/UID2-6762).
 
+## Jira-key ruleset compliance for automated release commits
+
+In-scope UID2/EUID repos enforce a GitHub `commit_message_pattern` ruleset (`require_jira_key`, UID2-7312) on the default branch: every commit must contain a `UID2-<n>` key or a reasoned opt-out `[no-jira - reason: <reason>]`. The ruleset has **no bypass actors**, so the release service account is subject to it like any human author.
+
+The automated release / version-bump commits produced by `actions/commit_pr_and_merge` (`[CI Pipeline] Released <type> version: X.Y.Z`) carry no Jira key, so the action appends a reasoned opt-out marker — `[no-jira - reason: automated release]` — to keep the merge recorded in history (the `uid2-github-alerts` archiver captures it) rather than granting a silent bypass (UID2-7400). Override the reason per call via the `no_jira_reason` input; it must be non-empty.
+
+The marker is applied in **two** places because the ruleset evaluates *every* commit a push introduces to the default branch, not just one:
+
+- **The branch commit** (`Commit to new branch` step) — always.
+- **The merge commit** (`Merge PR` step) — only on protected branches, where the action merges with `merge_method=merge` and GitHub generates an extra merge commit. Its default `Merge pull request #N ...` message carries no marker and would be rejected, so the action sets the merge commit message explicitly. On unprotected branches the action uses `merge_method=rebase`, which replays the already-marked branch commit and creates no merge commit.
+
+The marker goes in the commit message, not the branch name or PR title. This is a centralized change in the shared flow — it propagates to all consumers via `@v3`, so no per-repo edit is needed.
+
 ## Tips and tricks
 
 If you're trying to do something that should be simple, but can't find something that quite supports what you're trying to do, the [GitHub Script action](https://github.com/actions/github-script) gives you an authenticated GitHub API client and you can just provide a JavaScript script. For an example, see the "Tag commit" step in the [Commit, PR, and Merge](actions\commit-pr-and-merge\action.yaml) shared action.

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -11,8 +11,10 @@ inputs:
       Reason recorded in the [no-jira - reason: <reason>] marker appended to the
       commit message. These commits are automated and carry no Jira key, so the
       marker is a reasoned opt-out that satisfies the require_jira_key ruleset on
-      the default branch (UID2-7400 / UID2-7312). Override to give a more
-      specific reason; must be non-empty.
+      the default branch (UID2-7400 / UID2-7312). When `tag` is set it is
+      appended to the reason (e.g. "automated release v1.2.3") so the marker is
+      self-describing. Override to give a more specific reason; must be
+      non-empty.
     required: false
     default: automated release
   tag:
@@ -67,6 +69,7 @@ runs:
       env:
         MESSAGE: ${{ inputs.message }}
         NO_JIRA_REASON: ${{ inputs.no_jira_reason }}
+        TAG: ${{ inputs.tag }}
       run: |
         # Single source of truth for the CI commit message. The trailing
         # [no-jira - reason: <reason>] marker satisfies the require_jira_key
@@ -82,7 +85,38 @@ runs:
           echo "::error::no_jira_reason must be non-empty"
           exit 1
         fi
-        echo "message=[CI Pipeline] ${MESSAGE} [no-jira - reason: ${NO_JIRA_REASON}]" >> "$GITHUB_OUTPUT"
+
+        # Weave the release tag (e.g. v1.2.3) into the reason when present, so
+        # the marker is self-describing in the audit archive - UID2-7400 asks
+        # for "automated release vX.Y.Z". Non-release commits (pre-release /
+        # snapshot) pass no tag and keep the bare reason.
+        reason="$NO_JIRA_REASON"
+        if [[ -n "$TAG" ]]; then
+          reason="$reason $TAG"
+        fi
+
+        message="[CI Pipeline] ${MESSAGE} [no-jira - reason: ${reason}]"
+
+        # Guard the core invariant before it ships: the composed message must
+        # match the require_jira_key ruleset regex, which is enforced in a
+        # separate repo (uid2-okta-configuration). A drift here - spacing, the
+        # dash, a bracket - passes YAML/bash checks but would only surface as a
+        # merge rejection across every @v3 consumer ("all releases blocked").
+        # Assert against the exact pattern so drift fails here instead. Pin a
+        # UTF-8 locale: grep -P (PCRE) errors under a non-UTF-8 locale.
+        if ! printf '%s' "$message" | LC_ALL=C.UTF-8 grep -Pq 'UID2-[0-9]+|\[no-jira - reason:\s*\S[^\]]*\]'; then
+          echo "::error::composed commit message does not satisfy the require_jira_key ruleset: ${message}"
+          exit 1
+        fi
+
+        # Use the heredoc delimiter form (not single-line key=value): a message
+        # containing a newline would otherwise be truncated at the first \n,
+        # silently dropping the trailing marker.
+        {
+          echo "message<<__COMMIT_MSG_EOF__"
+          echo "$message"
+          echo "__COMMIT_MSG_EOF__"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Commit to new branch
       uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -6,6 +6,15 @@ inputs:
     description: Message for commit and PR title
     required: false
     default: Automated update
+  no_jira_reason:
+    description: >-
+      Reason recorded in the [no-jira - reason: <reason>] marker appended to the
+      commit message. These commits are automated and carry no Jira key, so the
+      marker is a reasoned opt-out that satisfies the require_jira_key ruleset on
+      the default branch (UID2-7400 / UID2-7312). Override to give a more
+      specific reason; must be non-empty.
+    required: false
+    default: automated release
   tag:
     description: If provided, this tag is applied to the commit
     required: false
@@ -52,12 +61,27 @@ runs:
       shell: bash
       run: echo "name=ci-${{ github.sha }}-${RANDOM}" >> $GITHUB_OUTPUT
 
+    - name: Compose commit message
+      id: compose
+      shell: bash
+      env:
+        MESSAGE: ${{ inputs.message }}
+        NO_JIRA_REASON: ${{ inputs.no_jira_reason }}
+      run: |
+        # Single source of truth for the CI commit message. The trailing
+        # [no-jira - reason: <reason>] marker satisfies the require_jira_key
+        # commit-message ruleset on the default branch (UID2-7400 / UID2-7312):
+        # these commits are automated and have no Jira key, so they carry a
+        # reasoned opt-out instead. Reused for the branch commit and, on
+        # protected branches, the merge commit (see the Merge PR step).
+        echo "message=[CI Pipeline] ${MESSAGE} [no-jira - reason: ${NO_JIRA_REASON}]" >> "$GITHUB_OUTPUT"
+
     - name: Commit to new branch
       uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
       if: steps.changes.outputs.changes_exist == 'true'
       id: create-branch-and-commit
       with:
-        message: '[CI Pipeline] ${{ inputs.message }}'
+        message: ${{ steps.compose.outputs.message }}
         author_name: Release Workflow
         author_email: unifiedid-admin+release@thetradedesk.com
         new_branch: ${{ steps.branch.outputs.name }}
@@ -88,11 +112,26 @@ runs:
         PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         BRANCH: ${{ steps.branch.outputs.name }}
         MERGE_METHOD: ${{ github.ref_protected == 'true' && 'merge' || 'rebase' }}
+        COMMIT_MESSAGE: ${{ steps.compose.outputs.message }}
       run: |
-        # Merge the PR
-        gh api --method PUT \
-          "repos/${{ github.repository }}/pulls/$PR_NUMBER/merge" \
-          -f merge_method="$MERGE_METHOD"
+        # Merge the PR.
+        #
+        # On protected branches this merges with merge_method=merge, which
+        # creates an extra merge commit. The require_jira_key ruleset
+        # (UID2-7400 / UID2-7312) evaluates *every* commit a push adds to the
+        # default branch - both the branch commit and this merge commit - and
+        # the default "Merge pull request #N ..." message carries no Jira key or
+        # opt-out marker, so the merge would be rejected. Set the merge commit
+        # message explicitly so it also complies.
+        #
+        # rebase merges (unprotected branches) replay the branch commit, which
+        # already carries the marker, and create no merge commit - so these
+        # fields are only sent for merge_method=merge.
+        merge_args=(--method PUT "repos/${{ github.repository }}/pulls/$PR_NUMBER/merge" -f merge_method="$MERGE_METHOD")
+        if [[ "$MERGE_METHOD" == "merge" ]]; then
+          merge_args+=(-f commit_title="$COMMIT_MESSAGE" -f commit_message="Automated release merge (PR #$PR_NUMBER).")
+        fi
+        gh api "${merge_args[@]}"
 
         # Delete the branch
         # || true - so the step doesn't fail if the branch is already deleted

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -74,6 +74,14 @@ runs:
         # these commits are automated and have no Jira key, so they carry a
         # reasoned opt-out instead. Reused for the branch commit and, on
         # protected branches, the merge commit (see the Merge PR step).
+        #
+        # Fail fast on an empty/whitespace reason: the ruleset requires a
+        # non-empty reason (\S), so "[no-jira - reason: ]" would otherwise be
+        # rejected at merge - far from the cause. Turn that into a clear error.
+        if [[ -z "${NO_JIRA_REASON//[[:space:]]/}" ]]; then
+          echo "::error::no_jira_reason must be non-empty"
+          exit 1
+        fi
         echo "message=[CI Pipeline] ${MESSAGE} [no-jira - reason: ${NO_JIRA_REASON}]" >> "$GITHUB_OUTPUT"
 
     - name: Commit to new branch


### PR DESCRIPTION
## What

Make the automated CI release / version-bump flow emit a commit message that satisfies the `require_jira_key` `commit_message_pattern` ruleset (UID2-7312) on the default branch.

The ruleset requires every commit to contain a `UID2-<n>` key or a reasoned opt-out `[no-jira - reason: <reason>]`, and has **no bypass actors** — so the release service account is subject to it like any human author. The version-bump commits produced by `actions/commit_pr_and_merge` (`[CI Pipeline] Released <type> version: X.Y.Z`) currently carry neither and would be **rejected at merge** once the rule is active.

## Approach

Append a reasoned opt-out marker — `[no-jira - reason: automated release]` — to the CI commit message (the recommended path in UID2-7400), rather than granting a silent bypass. This keeps the merge recorded in history so the `uid2-github-alerts` archiver captures it.

The fix is **centralized** in `commit_pr_and_merge` — the sole commit-creating action, used by all six versioned-publish workflows — so it propagates to every consumer via `@v3` with no per-repo change.

## Why two places (the merge-strategy question)

GitHub's `commit_message_pattern` ruleset evaluates **every commit a push introduces** to the default branch, not just one. This flow uses `merge_method=merge` on protected branches (and `rebase` otherwise), never squash — confirmed from `github.ref_protected` in the Merge step. So on the merge path both the incoming branch commit *and* the auto-generated merge commit are evaluated, and the default `Merge pull request #N ...` message carries no marker. The marker is therefore applied to:

- **the branch commit** — always, via a single `Compose commit message` step (single source of truth); and
- **the merge commit** — only on protected branches (`merge_method=merge`), by setting the merge commit message explicitly on the `gh api ... /merge` call. On `rebase` merges the marked branch commit is replayed and no merge commit is created, so these fields are only sent for `merge_method=merge`.

The marker goes in the **commit message**, not the branch name or PR title.

## Changes

- `actions/commit_pr_and_merge/action.yaml`
  - New optional input `no_jira_reason` (default `automated release`, must be non-empty; overridable per call).
  - New `Compose commit message` step producing `[CI Pipeline] <message> [no-jira - reason: <reason>]`, reused by the branch commit and the merge commit.
  - Merge step sets `commit_title`/`commit_message` for `merge_method=merge`.
- `README.md` — documents the compliance approach alongside the existing release-flow conventions.

## Validation

- Composed branch-commit and merge-commit messages both match the exact ruleset regex `UID2-[0-9]+|\[no-jira - reason:\s*\S[^\]]*\]`; the pre-change messages and a blank-reason opt-out are correctly rejected.
- `merge_args` array construction verified for both `merge` (sends the marker'd title) and `rebase` (does not) paths.
- `action.yaml` parses as valid YAML.

## Scope / out of scope

- No branch-protection, ruleset, or enforcement changes — those are handled separately in `uid2-okta-configuration`.
- Dependabot is not a meaningful factor for in-scope repos (per UID2-7400); if a UID2 repo adopts it, handle the same way (marker in the commit message, or exclude the repo).

Ticket: https://thetradedesk.atlassian.net/browse/UID2-7400

🤖 Generated with [Claude Code](https://claude.com/claude-code)
