### PR TITLE
UID2-7400: squash-merge CI release PRs (Option B), drop ref_protected branching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ In-scope UID2/EUID repos enforce a GitHub `commit_message_pattern` ruleset (`req
 
 The automated release / version-bump commits produced by `actions/commit_pr_and_merge` (`[CI Pipeline] Released <type> version: X.Y.Z`) carry no Jira key, so the action appends a reasoned opt-out marker — `[no-jira - reason: automated release v1.2.3]` — to keep the merge recorded in history (the `uid2-github-alerts` archiver captures it) rather than granting a silent bypass (UID2-7400). The release `tag` (when set) is woven into the reason so each marker is self-describing; override the reason per call via the `no_jira_reason` input (must be non-empty). The composed message is asserted against the ruleset regex at compose time, so a format drift fails the release run early rather than only at merge.
 
-The marker is applied in **two** places because the ruleset evaluates *every* commit a push introduces to the default branch, not just one:
+The version-bump PR is **squash-merged**, producing a single commit on the default branch. The marker is applied in **two** complementary spots so the rule is satisfied whether GitHub evaluates the resulting squash commit or every commit on the branch:
 
-- **The branch commit** (`Commit to new branch` step) — always.
-- **The merge commit** (`Merge PR` step) — only on protected branches, where the action merges with `merge_method=merge` and GitHub generates an extra merge commit. Its default `Merge pull request #N ...` message carries no marker and would be rejected, so the action sets the merge commit message explicitly. On unprotected branches the action uses `merge_method=rebase`, which replays the already-marked branch commit and creates no merge commit.
+- **The branch commit** (`Commit to new branch` step) — the single commit on the `ci-*` branch, marked via the compose step.
+- **The squash commit** (`Merge PR` step) — the action sets the squash commit message explicitly on the `gh api … /merge` call so it carries the marker too.
+
+The flow always squashes rather than selecting merge/rebase by branch-protection state. `github.ref_protected` reflects only *classic* branch protection, not rulesets, so on the ruleset-governed default branches we target it reads `false` and the previous logic silently rebased (the merge-commit path never fired). Squashing unconditionally keeps behaviour uniform across consumers and complies with the squash-only merge rule without granting the release account a ruleset bypass. Consumers must allow squash merging (guaranteed where the squash-only rule applies).
 
 The marker goes in the commit message, not the branch name or PR title. This is a centralized change in the shared flow — it propagates to all consumers via `@v3`, so no per-repo edit is needed.
 

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -75,8 +75,8 @@ runs:
         # [no-jira - reason: <reason>] marker satisfies the require_jira_key
         # commit-message ruleset on the default branch (UID2-7400 / UID2-7312):
         # these commits are automated and have no Jira key, so they carry a
-        # reasoned opt-out instead. Reused for the branch commit and, on
-        # protected branches, the merge commit (see the Merge PR step).
+        # reasoned opt-out instead. Reused for the branch commit and the squash
+        # commit (see the Merge PR step).
         #
         # Fail fast on an empty/whitespace reason: the ruleset requires a
         # non-empty reason (\S), so "[no-jira - reason: ]" would otherwise be
@@ -153,27 +153,29 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token == '' && github.token || inputs.github_token }}
         PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         BRANCH: ${{ steps.branch.outputs.name }}
-        MERGE_METHOD: ${{ github.ref_protected == 'true' && 'merge' || 'rebase' }}
         COMMIT_MESSAGE: ${{ steps.compose.outputs.message }}
       run: |
-        # Merge the PR.
+        # Squash-merge the PR.
         #
-        # On protected branches this merges with merge_method=merge, which
-        # creates an extra merge commit. The require_jira_key ruleset
-        # (UID2-7400 / UID2-7312) evaluates *every* commit a push adds to the
-        # default branch - both the branch commit and this merge commit - and
-        # the default "Merge pull request #N ..." message carries no Jira key or
-        # opt-out marker, so the merge would be rejected. Set the merge commit
-        # message explicitly so it also complies.
+        # The flow always squashes - it does not pick merge/rebase by
+        # branch-protection state. github.ref_protected only reflects *classic*
+        # branch protection, not rulesets, so on the ruleset-governed default
+        # branches we target it reads false and the old logic silently rebased;
+        # the merge-commit path never fired. Squashing unconditionally makes the
+        # result uniform across consumers regardless of how their default branch
+        # is protected, and complies with the squash-only merge rule without
+        # granting the release account a ruleset bypass.
         #
-        # rebase merges (unprotected branches) replay the branch commit, which
-        # already carries the marker, and create no merge commit - so these
-        # fields are only sent for merge_method=merge.
-        merge_args=(--method PUT "repos/${{ github.repository }}/pulls/$PR_NUMBER/merge" -f merge_method="$MERGE_METHOD")
-        if [[ "$MERGE_METHOD" == "merge" ]]; then
-          merge_args+=(-f commit_title="$COMMIT_MESSAGE" -f commit_message="Automated release merge (PR #$PR_NUMBER).")
-        fi
-        gh api "${merge_args[@]}"
+        # A squash merge lands a single commit whose message we set explicitly,
+        # so it carries the require_jira_key marker (UID2-7400 / UID2-7312). The
+        # ci-* branch also holds exactly one already-marked commit (see Compose
+        # commit message), so the rule is satisfied whether GitHub evaluates the
+        # resulting squash commit or every commit on the branch.
+        gh api --method PUT \
+          "repos/${{ github.repository }}/pulls/$PR_NUMBER/merge" \
+          -f merge_method="squash" \
+          -f commit_title="$COMMIT_MESSAGE" \
+          -f commit_message="Automated release (PR #$PR_NUMBER)."
 
         # Delete the branch
         # || true - so the step doesn't fail if the branch is already deleted


### PR DESCRIPTION
## What

Follow-up to [#247](https://github.com/IABTechLab/uid2-shared-actions/pull/247). Switch the CI release / version-bump flow in `commit_pr_and_merge` to **always squash-merge**, dropping the `github.ref_protected ? 'merge' : 'rebase'` selection.

## Why

`github.ref_protected` reflects only **classic branch protection, not rulesets**. The in-scope default branches are ruleset-governed, so it reads `false` and the flow was silently **rebasing** — meaning #247's merge-commit marking never fired for the actual target repos.

Verified live on `uid2-operator`:
- Its last release commits (`5.70.191–193`) are **single-parent** (rebase), not merge commits.
- Its `main` is governed by rulesets (`default-branch-pr-review`, `default-branch-push-restrictions`, active since Mar/Apr 2026) with no classic protection.
- (Also confirmed the `require_jira_key` rule is **not yet active** there — full end-to-end validation still rides UID2-7312 enablement.)

This implements the **Option B** decision on the squash-only merge rule: rather than bypassing the release account on that rule, make the bot squash like everyone else.

## Change

- Merge step: unconditional `merge_method=squash`, always setting `commit_title`/`commit_message` (a squash merge honours them). Removed the `ref_protected`-based `MERGE_METHOD` and the `merge`-only guard.
- The marking mechanism from #247 transfers directly — the single squash commit carries the marker, and the `ci-*` branch still holds exactly one already-marked commit, so the rule passes whether GitHub evaluates the squash commit or every branch commit.
- Compose step comment + README updated to describe the squash model and why `ref_protected` is not used.

## Safety

- `Tag commit` / `Get commit SHA` read `pr.merge_commit_sha`, which a squash merge populates — tagging/releases unaffected.
- Net simplification: removes the proven-dead merge-commit branch rather than reworking it; the `[no-jira - reason: …]` marker, regex self-check, tag-weaving, empty-reason guard, and heredoc output from #247 are all retained.

## Rollout

- Consumers must allow squash merging — guaranteed where the squash-only rule applies; UID2 repos allow it by default.
- After merge, move the `v3` tag (publish a `v3.NN` release; `update-major-version-tags` advances `v3`) before consumers pick this up.

Ticket: https://thetradedesk.atlassian.net/browse/UID2-7400

🤖 Generated with [Claude Code](https://claude.com/claude-code)
