### PR TITLE
UID2-7011: fix template-injection findings in shared workflows

### DIFF
--- a/.github/workflows/shared-increase-version-number.yaml
+++ b/.github/workflows/shared-increase-version-number.yaml
@@ -55,10 +55,14 @@ jobs:
 
       - name: Update ${{ inputs.working_dir }}/package.json
         id: updatePackageJson
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
           current_version=$(jq -r '.version')
           new_version=${{ steps.version.outputs.new_version }}
-          jq --arg v "$new_version" ".version = \$v" "${{ inputs.working_dir }}/package.json" > tmp.json && mv tmp.json "${{ inputs.working_dir }}/package.json"
+          jq --arg v "$new_version" ".version = \$v" "${WORKING_DIR}/package.json" > tmp.json && mv tmp.json "${WORKING_DIR}/package.json"
           echo "Version number updated from $current_version to $new_version"
           echo "image_tag=${{ steps.version.outputs.new_version }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/shared-promote-auto-pr.yaml
+++ b/.github/workflows/shared-promote-auto-pr.yaml
@@ -9,12 +9,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create Pull Request
         run: |
-          echo "branch ${{ github.ref }} was pushed to"
-          if [ ${{ github.ref }} == "refs/heads/main" ]; then
+          # Use the runner-provided $GITHUB_REF env var instead of expanding the
+          # github.ref expression into the script — branch names are user-controlled,
+          # so template expansion here is shell injection (zizmor: template-injection).
+          echo "branch ${GITHUB_REF} was pushed to"
+          if [ "${GITHUB_REF}" == "refs/heads/main" ]; then
             base="test"
-          elif [ ${{ github.ref }} == "refs/heads/test" ]; then
+          elif [ "${GITHUB_REF}" == "refs/heads/test" ]; then
             base="integ"
-          elif [ ${{ github.ref }} == "refs/heads/integ" ]; then
+          elif [ "${GITHUB_REF}" == "refs/heads/integ" ]; then
             base="prod"
           else
             exit 0

--- a/.github/workflows/shared-publish-java-to-docker-versioned.yaml
+++ b/.github/workflows/shared-publish-java-to-docker-versioned.yaml
@@ -127,8 +127,12 @@ jobs:
 
       - name: Update pom.xml
         id: updatePom
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          pushd ${{ inputs.working_dir }}
+          pushd "${WORKING_DIR}"
           current_version=$(grep -o '<version>.*</version>' pom.xml | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
           new_version=${{ steps.version.outputs.new_version }} 
           mvn versions:set versions:commit -DnewVersion="$new_version"
@@ -138,8 +142,10 @@ jobs:
 
       - name: Package JAR
         id: package
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          pushd ${{ inputs.working_dir }}
+          pushd "${WORKING_DIR}"
           cat pom.xml
           if [[ "${{ inputs.skip_tests }}" == "false" ]]; then
             mvn -B package -P default
@@ -194,8 +200,13 @@ jobs:
 
       - name: Lowercase image reference
         id: imageRef
+        env:
+          # REGISTRY/IMAGE_NAME are workflow-level env vars already in the shell;
+          # append_image_name is a caller-controlled input passed via env rather
+          # than expanded into the script (zizmor: template-injection).
+          APPEND_IMAGE_NAME: ${{ inputs.append_image_name }}
         run: |
-          value="$(printf '%s' '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ inputs.append_image_name }}' | tr '[:upper:]' '[:lower:]')"
+          value="$(printf '%s' "${REGISTRY}/${IMAGE_NAME}${APPEND_IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
           echo "value=${value}" >> "$GITHUB_OUTPUT"
 
       - name: Build and export to Docker

--- a/.github/workflows/shared-publish-to-ios-version.yaml
+++ b/.github/workflows/shared-publish-to-ios-version.yaml
@@ -69,22 +69,28 @@ jobs:
           swiftlint lint --config .swiftlint.yml --reporter github-actions-logging
 
       - name: Update UID2.Client.ios
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          formatted_current_version=$(grep -o '\d*,\s*\d*,\s*\d*' ${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift | head -1)
+          formatted_current_version=$(grep -o '\d*,\s*\d*,\s*\d*' "${WORKING_DIR}/Sources/UID2/Properties/UID2SDKProperties.swift" | head -1)
           current_version=$(echo "$formatted_current_version" | sed 's/\(.*\),[[:space:]]*\(.*\),[[:space:]]*\(.*\)/\1.\2.\3/')
-          new_version=${{ steps.version.outputs.new_version }} 
+          new_version=${{ steps.version.outputs.new_version }}
           formatted_new_version=$(echo "$new_version" | sed 's/\([[:digit:]]\)\.\([[:digit:]]\)\.\([[:digit:]]\)/\1, \2, \3/')
-          sed -i '' -e "s/$formatted_current_version/$formatted_new_version/g" ${{ inputs.working_dir }}/Sources/UID2/Properties/UID2SDKProperties.swift
-          jq --arg VERSION "$new_version" --arg TAG "v$new_version" '. | .version |= $VERSION | .source.tag |= $TAG' ${{ inputs.working_dir }}/UID2.podspec.json >${{ inputs.working_dir }}/UID2.podspec.json.tmp && mv ${{ inputs.working_dir }}/UID2.podspec.json.tmp ${{ inputs.working_dir }}/UID2.podspec.json
-          jq --arg VERSION "$new_version" --arg TAG "v$new_version" '. | .version |= $VERSION | .source.tag |= $TAG' ${{ inputs.working_dir }}/UID2Prebid.podspec.json > ${{ inputs.working_dir }}/UID2Prebid.podspec.json.tmp && mv ${{ inputs.working_dir }}/UID2Prebid.podspec.json.tmp ${{ inputs.working_dir }}/UID2Prebid.podspec.json
+          sed -i '' -e "s/$formatted_current_version/$formatted_new_version/g" "${WORKING_DIR}/Sources/UID2/Properties/UID2SDKProperties.swift"
+          jq --arg VERSION "$new_version" --arg TAG "v$new_version" '. | .version |= $VERSION | .source.tag |= $TAG' "${WORKING_DIR}/UID2.podspec.json" >"${WORKING_DIR}/UID2.podspec.json.tmp" && mv "${WORKING_DIR}/UID2.podspec.json.tmp" "${WORKING_DIR}/UID2.podspec.json"
+          jq --arg VERSION "$new_version" --arg TAG "v$new_version" '. | .version |= $VERSION | .source.tag |= $TAG' "${WORKING_DIR}/UID2Prebid.podspec.json" > "${WORKING_DIR}/UID2Prebid.podspec.json.tmp" && mv "${WORKING_DIR}/UID2Prebid.podspec.json.tmp" "${WORKING_DIR}/UID2Prebid.podspec.json"
           echo "Version number updated from $current_version to $new_version"
 
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Build, Test
-        run: | 
-          cd ./${{ inputs.working_dir }}
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
+        run: |
+          cd "./${WORKING_DIR}"
           xcodebuild -scheme UID2 -destination "generic/platform=iOS"
           xcodebuild test -scheme UID2 -destination "OS=26.2,name=iPhone 17"
           xcodebuild -scheme UID2Prebid -destination "generic/platform=iOS"

--- a/.github/workflows/shared-publish-to-maven-versioned.yaml
+++ b/.github/workflows/shared-publish-to-maven-versioned.yaml
@@ -107,14 +107,20 @@ jobs:
           working_dir: ${{ inputs.working_dir }}
 
       - name: Update pom.xml
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          current_version=$(grep -o '<version>.*</version>' ${{ inputs.working_dir }}/pom.xml | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
-          new_version=${{ steps.version.outputs.new_version }} 
-          sed -i "s/$current_version/$new_version/g" ${{ inputs.working_dir }}/pom.xml
+          current_version=$(grep -o '<version>.*</version>' "${WORKING_DIR}/pom.xml" | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
+          new_version=${{ steps.version.outputs.new_version }}
+          sed -i "s/$current_version/$new_version/g" "${WORKING_DIR}/pom.xml"
           echo "Version number updated from $current_version to $new_version"
       - name: Create Maven Settings
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          cd ./${{ inputs.working_dir }}
+          cd "./${WORKING_DIR}"
           echo "<settings>
                     <servers>
                         <server>
@@ -128,22 +134,27 @@ jobs:
 
       - name: Publish
         if: ${{ inputs.publish_to_maven }}
-        run: | 
-          cd ./${{ inputs.working_dir }}
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
+        run: |
+          cd "./${WORKING_DIR}"
           mvn -B -s settings.xml -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" clean deploy
 
       - name: Compile
         if: ${{ inputs.publish_to_maven != true && inputs.skip_tests == false }}
         env:
           EXTRA_FLAGS: "-s settings.xml -Dgpg.passphrase=\"${{ secrets.GPG_PASSPHRASE }}\""
-        run: | 
-          cd ./${{ inputs.working_dir }}
+          WORKING_DIR: ${{ inputs.working_dir }}
+        run: |
+          cd "./${WORKING_DIR}"
           bash uid2-shared-actions/scripts/compile_java_test_and_verify.sh -s settings.xml -D gpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
 
       - name: Compile with no tests
         if: ${{ inputs.publish_to_maven != true && inputs.skip_tests == true }}
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          cd ./${{ inputs.working_dir }}
+          cd "./${WORKING_DIR}"
           mvn -B -s settings.xml -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" clean compile -DskipTests
 
       - name: Commit pom.xml and version.json
@@ -166,6 +177,8 @@ jobs:
       - name: Extract Maven artifactId
         id: package_name
         if: ${{ steps.checkRelease.outputs.is_release == 'true' }}
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
           # Maven artifactId comes from pom.xml, not the github repo name
           # (e.g. uid2-attestation-azure repo publishes the `attestation-azure`
@@ -173,9 +186,9 @@ jobs:
           # release-notes install snippets match what `mvn deploy` actually
           # published. Gated on is_release to avoid running on Snapshot builds
           # where shared_create_releases is a no-op.
-          artifact_id=$(mvn -B -f "${{ inputs.working_dir }}/pom.xml" help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+          artifact_id=$(mvn -B -f "${WORKING_DIR}/pom.xml" help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
           if [ -z "$artifact_id" ]; then
-            echo "ERROR: could not extract artifactId from ${{ inputs.working_dir }}/pom.xml" >&2
+            echo "ERROR: could not extract artifactId from ${WORKING_DIR}/pom.xml" >&2
             exit 1
           fi
           echo "Extracted Maven artifactId: $artifact_id"

--- a/.github/workflows/shared-publish-to-nuget-versioned.yaml
+++ b/.github/workflows/shared-publish-to-nuget-versioned.yaml
@@ -72,15 +72,21 @@ jobs:
           working_dir: ${{ inputs.working_dir }}
 
       - name: Update UID2.Client.nuspec
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          current_version=$(grep -o '<version>.*</version>' ${{ inputs.working_dir }}/UID2.Client.nuspec | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
-          new_version=${{ steps.version.outputs.new_version }} 
-          sed -i "s/$current_version/$new_version/g" ${{ inputs.working_dir }}/UID2.Client.nuspec
+          current_version=$(grep -o '<version>.*</version>' "${WORKING_DIR}/UID2.Client.nuspec" | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
+          new_version=${{ steps.version.outputs.new_version }}
+          sed -i "s/$current_version/$new_version/g" "${WORKING_DIR}/UID2.Client.nuspec"
           echo "Version number updated from $current_version to $new_version"
 
       - name: Build and test
-        run: | 
-          cd ./${{ inputs.working_dir }}
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
+        run: |
+          cd "./${WORKING_DIR}"
           dotnet test --configuration=Release
           dotnet pack -p:NuspecFile=../../UID2.Client.nuspec --configuration Release
 
@@ -114,6 +120,8 @@ jobs:
       - name: Extract NuGet package id
         id: package_name
         if: ${{ steps.checkRelease.outputs.is_release == 'true' }}
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
           # NuGet package id comes from the <id> element in the .nuspec, not
           # the github repo name. Use xmllint's local-name() XPath so we
@@ -129,7 +137,7 @@ jobs:
           # solves half of the single-tenancy problem flagged in UID2-7069 —
           # a follow-up should parameterise the .nuspec filename via a
           # workflow input.
-          nuspec="${{ inputs.working_dir }}/UID2.Client.nuspec"
+          nuspec="${WORKING_DIR}/UID2.Client.nuspec"
           package_id=$(xmllint --xpath 'string(//*[local-name()="package"]/*[local-name()="metadata"]/*[local-name()="id"])' "$nuspec")
           if [ -z "$package_id" ]; then
             echo "ERROR: could not extract <id> from $nuspec" >&2

--- a/.github/workflows/shared-publish-to-pypi-versioned.yaml
+++ b/.github/workflows/shared-publish-to-pypi-versioned.yaml
@@ -72,11 +72,15 @@ jobs:
           working_dir: ${{ inputs.working_dir }}
 
       - name: Update pyproject.toml
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          OLD_VERSION=`cat ${{ inputs.working_dir }}/pyproject.toml | grep ^version | cut -d '"' -f 2`
+          OLD_VERSION=`cat "${WORKING_DIR}/pyproject.toml" | grep ^version | cut -d '"' -f 2`
           OLD_VERSION="\"$OLD_VERSION\""
           NEW_VERSION="\"${{ steps.version.outputs.new_version }}\""
-          sed -i "s+version = $OLD_VERSION+version = $NEW_VERSION+g" ${{ inputs.working_dir }}/pyproject.toml
+          sed -i "s+version = $OLD_VERSION+version = $NEW_VERSION+g" "${WORKING_DIR}/pyproject.toml"
 
       - name: Build
         run: |
@@ -100,6 +104,8 @@ jobs:
       - name: Extract PyPI package name
         id: package_name
         if: ${{ steps.checkRelease.outputs.is_release == 'true' }}
+        env:
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
           # PyPI package name comes from pyproject.toml, not the github repo name
           # (e.g. uid2-client-python repo publishes the `uid2_client` package).
@@ -120,9 +126,9 @@ jobs:
           # the KeyError this would raise is loud but unhelpful. No current
           # PyPI consumer uses Poetry, so leaving the PEP 621 assumption
           # in place.
-          name=$(python3 -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['name'])" "${{ inputs.working_dir }}/pyproject.toml")
+          name=$(python3 -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['name'])" "${WORKING_DIR}/pyproject.toml")
           if [ -z "$name" ]; then
-            echo "ERROR: could not extract [project].name from ${{ inputs.working_dir }}/pyproject.toml" >&2
+            echo "ERROR: could not extract [project].name from ${WORKING_DIR}/pyproject.toml" >&2
             exit 1
           fi
           echo "Extracted PyPI package name: $name"

--- a/.github/workflows/shared-validate-image.yaml
+++ b/.github/workflows/shared-validate-image.yaml
@@ -61,11 +61,15 @@ jobs:
       - name: Package JAR
         id: package
         shell: bash
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          CLOUD_PROVIDER: ${{ inputs.cloud_provider }}
         run: |
           if [[ "${{ inputs.skip_tests }}" == "false" ]]; then
-            mvn -B package -P ${{ inputs.cloud_provider }}
+            mvn -B package -P "${CLOUD_PROVIDER}"
           else
-            mvn -B package -P ${{ inputs.cloud_provider }} -DskipTests
+            mvn -B package -P "${CLOUD_PROVIDER}" -DskipTests
           fi
           echo "jar_version=$(mvn help:evaluate -Dexpression=project.version | grep -e '^[1-9][^\[]')" >> $GITHUB_OUTPUT
           echo "git_commit=$(git show --format="%h" --no-patch)" >> $GITHUB_OUTPUT

--- a/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
@@ -66,8 +66,12 @@ jobs:
       - name: Package JAR
         if: inputs.scan_type == 'image' && inputs.dockerfile == ''
         id: package
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          pushd ${{ inputs.working_dir }}
+          pushd "${WORKING_DIR}"
           if [[ "${{ inputs.skip_tests }}" == "false" ]]; then
             mvn -B package -P default
           else


### PR DESCRIPTION
Fixes all 29 High-severity zizmor `template-injection` findings in the reusable workflows (UID2-7011 rollout: get High to zero, then flip `fail_severity: high`). Sibling PRs: #250, #251.

**Fix pattern:** each flagged `${{ ... }}` inside a `run:` block is hoisted to a step-level `env:` var and referenced as a quoted shell variable. Expansion happens before the shell parses the script, so a value with shell metacharacters (caller input, or a crafted branch name via `github.ref`) would execute; via env the shell only sees a variable dereference. No behaviour change for benign values.

- `github.ref` → the runner's `$GITHUB_REF` (shared-promote-auto-pr)
- `inputs.working_dir` → `WORKING_DIR` (increase-version-number, ios/maven/nuget/pypi/java-docker publish, vuln-scan-failure-notify)
- `inputs.cloud_provider` → `CLOUD_PROVIDER` (validate-image); `inputs.append_image_name` → `APPEND_IMAGE_NAME` (java-docker)

**Verification:** `zizmor --offline --min-severity high` over `.github/workflows` now exits 0 (was 29); actionlint findings identical to main. Quoting audit in the comment below.

**Known accepted residual:** `steps.version.outputs.new_version` stays inline in some run blocks — zizmor rates step-output expansions Informational (below our `high` floor), the tainted path needs write access, and `check_branch_and_release_type` blocks it in 5 of 6 consumers. Revisit if `min_severity` is lowered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
