### PR TITLE
UID2-7011: fix template-injection in run_e2e_tests and version_number actions

### DIFF
--- a/actions/run_e2e_tests/action.yaml
+++ b/actions/run_e2e_tests/action.yaml
@@ -48,24 +48,42 @@ runs:
   steps:
     - name: Pull E2E image
       shell: bash
+      env:
+        # Inputs are passed via env rather than expanded into the scripts below:
+        # they are caller-controlled strings, and template expansion inside a run
+        # block is shell injection (zizmor: template-injection).
+        E2E_IMAGE_VERSION: ${{ inputs.e2e_image_version }}
       run: |
-        docker pull ghcr.io/iabtechlab/uid2-e2e:${{ inputs.e2e_image_version }}
+        docker pull "ghcr.io/iabtechlab/uid2-e2e:${E2E_IMAGE_VERSION}"
         docker images
 
     - name: Run mock E2E tests
       if: ${{ inputs.e2e_env == 'github-test-pipeline-local' }}
       shell: bash
+      env:
+        E2E_IMAGE_VERSION: ${{ inputs.e2e_image_version }}
+        E2E_SUITES: ${{ inputs.e2e_suites }}
+        E2E_ENV: ${{ inputs.e2e_env }}
+        E2E_IDENTITY_SCOPE: ${{ inputs.e2e_identity_scope }}
+        E2E_PHONE_SUPPORT: ${{ inputs.e2e_phone_support }}
+        UID2_CORE_E2E_CORE_URL: ${{ inputs.uid2_core_e2e_core_url }}
+        UID2_CORE_E2E_OPTOUT_URL: ${{ inputs.uid2_core_e2e_optout_url }}
+        UID2_PIPELINE_E2E_CORE_URL: ${{ inputs.uid2_pipeline_e2e_core_url }}
+        UID2_PIPELINE_E2E_OPERATOR_URL: ${{ inputs.uid2_pipeline_e2e_operator_url }}
+        UID2_PIPELINE_E2E_OPERATOR_TYPE: ${{ inputs.uid2_pipeline_e2e_operator_type }}
+        UID2_PIPELINE_E2E_OPERATOR_CLOUD_PROVIDER: ${{ inputs.uid2_pipeline_e2e_operator_cloud_provider }}
+        E2E_NETWORK: ${{ inputs.e2e_network }}
       run: |
         docker run \
-        --env E2E_SUITES=${{ inputs.e2e_suites }} \
-        --env E2E_ENV=${{ inputs.e2e_env }} \
-        --env E2E_IDENTITY_SCOPE='${{ inputs.e2e_identity_scope }}' \
-        --env E2E_PHONE_SUPPORT='${{ inputs.e2e_phone_support }}' \
+        --env E2E_SUITES="${E2E_SUITES}" \
+        --env E2E_ENV="${E2E_ENV}" \
+        --env E2E_IDENTITY_SCOPE="${E2E_IDENTITY_SCOPE}" \
+        --env E2E_PHONE_SUPPORT="${E2E_PHONE_SUPPORT}" \
         --env UID2_CORE_E2E_OPERATOR_API_KEY='UID2-O-L-999-dp9Dt0.JVoGpynN4J8nMA7FxmzsavxJa8B9H74y9xdEE=' \
         --env UID2_CORE_E2E_OPTOUT_API_KEY='UID2-O-L-127-pDqphU.6FuXzThQMY8YEsCA8crqvAlzyGrjcF8P6XO84=' \
         --env UID2_CORE_E2E_OPTOUT_INTERNAL_API_KEY='test-optout-internal-key' \
-        --env UID2_CORE_E2E_CORE_URL='${{ inputs.uid2_core_e2e_core_url }}' \
-        --env UID2_CORE_E2E_OPTOUT_URL='${{ inputs.uid2_core_e2e_optout_url }}' \
+        --env UID2_CORE_E2E_CORE_URL="${UID2_CORE_E2E_CORE_URL}" \
+        --env UID2_CORE_E2E_OPTOUT_URL="${UID2_CORE_E2E_OPTOUT_URL}" \
         --env UID2_OPERATOR_E2E_CLIENT_SITE_ID='999' \
         --env UID2_OPERATOR_E2E_CLIENT_API_KEY='UID2-C-L-999-fCXrMM.fsR3mDqAXELtWWMS+xG1s7RdgRTMqdOH2qaAo=' \
         --env UID2_OPERATOR_E2E_CLIENT_API_SECRET='DzBzbjTJcYL0swDtFs2krRNu+g1Eokm2tBU4dEuD0Wk=' \
@@ -77,28 +95,42 @@ runs:
         --env UID2_OPERATOR_E2E_CSTG_SERVER_PUBLIC_KEY='UID2-X-L-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWyCP9O/6ppffj8f5PUWsEhAoMNdTBnpnkiOPZBkVnLkxOyTjPsKzf5J3ApPHzutAGNGgKAzFc6TuCfo+BWsZtQ==' \
         --env UID2_OPERATOR_E2E_CSTG_ORIGIN='https://example.com' \
         --env UID2_OPERATOR_E2E_CSTG_INVALID_ORIGIN='https://example.org' \
-        --env UID2_PIPELINE_E2E_CORE_URL='${{ inputs.uid2_pipeline_e2e_core_url }}' \
-        --env UID2_PIPELINE_E2E_OPERATOR_URL='${{ inputs.uid2_pipeline_e2e_operator_url }}' \
-        --env UID2_PIPELINE_E2E_OPERATOR_TYPE='${{ inputs.uid2_pipeline_e2e_operator_type }}' \
-        --env UID2_PIPELINE_E2E_OPERATOR_CLOUD_PROVIDER='${{ inputs.uid2_pipeline_e2e_operator_cloud_provider }}' \
-        --network '${{ inputs.e2e_network }}' \
-        ghcr.io/iabtechlab/uid2-e2e:${{ inputs.e2e_image_version }}
+        --env UID2_PIPELINE_E2E_CORE_URL="${UID2_PIPELINE_E2E_CORE_URL}" \
+        --env UID2_PIPELINE_E2E_OPERATOR_URL="${UID2_PIPELINE_E2E_OPERATOR_URL}" \
+        --env UID2_PIPELINE_E2E_OPERATOR_TYPE="${UID2_PIPELINE_E2E_OPERATOR_TYPE}" \
+        --env UID2_PIPELINE_E2E_OPERATOR_CLOUD_PROVIDER="${UID2_PIPELINE_E2E_OPERATOR_CLOUD_PROVIDER}" \
+        --network "${E2E_NETWORK}" \
+        "ghcr.io/iabtechlab/uid2-e2e:${E2E_IMAGE_VERSION}"
 
     - name: Run real E2E tests
       if: ${{ inputs.e2e_env == 'github-test-pipeline' }}
       shell: bash
+      env:
+        E2E_IMAGE_VERSION: ${{ inputs.e2e_image_version }}
+        E2E_SUITES: ${{ inputs.e2e_suites }}
+        E2E_ARGS_JSON: ${{ inputs.e2e_args_json }}
+        E2E_ENV: ${{ inputs.e2e_env }}
+        E2E_IDENTITY_SCOPE: ${{ inputs.e2e_identity_scope }}
+        E2E_PHONE_SUPPORT: ${{ inputs.e2e_phone_support }}
+        UID2_CORE_E2E_CORE_URL: ${{ inputs.uid2_core_e2e_core_url }}
+        UID2_CORE_E2E_OPTOUT_URL: ${{ inputs.uid2_core_e2e_optout_url }}
+        UID2_PIPELINE_E2E_CORE_URL: ${{ inputs.uid2_pipeline_e2e_core_url }}
+        UID2_PIPELINE_E2E_OPERATOR_URL: ${{ inputs.uid2_pipeline_e2e_operator_url }}
+        UID2_PIPELINE_E2E_OPERATOR_TYPE: ${{ inputs.uid2_pipeline_e2e_operator_type }}
+        UID2_PIPELINE_E2E_OPERATOR_CLOUD_PROVIDER: ${{ inputs.uid2_pipeline_e2e_operator_cloud_provider }}
+        E2E_NETWORK: ${{ inputs.e2e_network }}
       run: |
         docker run \
-        --env E2E_SUITES='${{ inputs.e2e_suites }}' \
-        --env E2E_ARGS_JSON='${{ inputs.e2e_args_json }}' \
-        --env E2E_ENV='${{ inputs.e2e_env }}' \
-        --env E2E_IDENTITY_SCOPE='${{ inputs.e2e_identity_scope }}' \
-        --env E2E_PHONE_SUPPORT='${{ inputs.e2e_phone_support }}' \
-        --env UID2_CORE_E2E_CORE_URL='${{ inputs.uid2_core_e2e_core_url }}' \
-        --env UID2_CORE_E2E_OPTOUT_URL='${{ inputs.uid2_core_e2e_optout_url }}' \
-        --env UID2_PIPELINE_E2E_CORE_URL='${{ inputs.uid2_pipeline_e2e_core_url }}' \
-        --env UID2_PIPELINE_E2E_OPERATOR_URL='${{ inputs.uid2_pipeline_e2e_operator_url }}' \
-        --env UID2_PIPELINE_E2E_OPERATOR_TYPE='${{ inputs.uid2_pipeline_e2e_operator_type }}' \
-        --env UID2_PIPELINE_E2E_OPERATOR_CLOUD_PROVIDER='${{ inputs.uid2_pipeline_e2e_operator_cloud_provider }}' \
-        --network '${{ inputs.e2e_network }}' \
-        ghcr.io/iabtechlab/uid2-e2e:${{ inputs.e2e_image_version }}
+        --env E2E_SUITES="${E2E_SUITES}" \
+        --env E2E_ARGS_JSON="${E2E_ARGS_JSON}" \
+        --env E2E_ENV="${E2E_ENV}" \
+        --env E2E_IDENTITY_SCOPE="${E2E_IDENTITY_SCOPE}" \
+        --env E2E_PHONE_SUPPORT="${E2E_PHONE_SUPPORT}" \
+        --env UID2_CORE_E2E_CORE_URL="${UID2_CORE_E2E_CORE_URL}" \
+        --env UID2_CORE_E2E_OPTOUT_URL="${UID2_CORE_E2E_OPTOUT_URL}" \
+        --env UID2_PIPELINE_E2E_CORE_URL="${UID2_PIPELINE_E2E_CORE_URL}" \
+        --env UID2_PIPELINE_E2E_OPERATOR_URL="${UID2_PIPELINE_E2E_OPERATOR_URL}" \
+        --env UID2_PIPELINE_E2E_OPERATOR_TYPE="${UID2_PIPELINE_E2E_OPERATOR_TYPE}" \
+        --env UID2_PIPELINE_E2E_OPERATOR_CLOUD_PROVIDER="${UID2_PIPELINE_E2E_OPERATOR_CLOUD_PROVIDER}" \
+        --network "${E2E_NETWORK}" \
+        "ghcr.io/iabtechlab/uid2-e2e:${E2E_IMAGE_VERSION}"

--- a/actions/version_number/action.yaml
+++ b/actions/version_number/action.yaml
@@ -27,22 +27,30 @@ runs:
     - name: Update Major Version
       if: inputs.type == 'Major' && inputs.version_number == ''
       shell: bash
+      env:
+        # Inputs are passed via env rather than expanded into the scripts below:
+        # they are caller-controlled strings (branch_name in particular is usually
+        # github.ref), and template expansion inside a run block is shell
+        # injection (zizmor: template-injection).
+        WORKING_DIR: ${{ inputs.working_dir }}
       run: |
-        old_ver=$(jq '.version' ${{ inputs.working_dir }}/version.json | tr -d '"')
+        old_ver=$(jq '.version' "${WORKING_DIR}/version.json" | tr -d '"')
         new_ver=$(echo $old_ver | cut -d'.' -f 1) #get the major number
         new_ver=$(echo $(expr $new_ver + 1))      #increment
         new_ver=$(echo $new_ver.0)                #set minor version to 0
         new_ver=\"$new_ver\"
-        echo $(jq ".version=$new_ver" ${{ inputs.working_dir }}/version.json) > ${{ inputs.working_dir }}/version.json
+        echo $(jq ".version=$new_ver" "${WORKING_DIR}/version.json") > "${WORKING_DIR}/version.json"
 
     - name: Update Minor Version
       if: inputs.type == 'Minor' && inputs.version_number == ''
       shell: bash
+      env:
+        WORKING_DIR: ${{ inputs.working_dir }}
       run: |
-        old_ver=$(jq '.version' ${{ inputs.working_dir }}/version.json | tr -d '"')
+        old_ver=$(jq '.version' "${WORKING_DIR}/version.json" | tr -d '"')
         new_ver=$(echo $old_ver | awk -F. -v OFS=. '{$NF++; print $0}') # minor
         new_ver=\"$new_ver\"
-        echo $(jq ".version=$new_ver" ${{ inputs.working_dir }}/version.json) > ${{ inputs.working_dir }}/version.json
+        echo $(jq ".version=$new_ver" "${WORKING_DIR}/version.json") > "${WORKING_DIR}/version.json"
 
     - name: Set Version
       if:  inputs.version_number == ''
@@ -61,16 +69,20 @@ runs:
     - name: Calculate Version Number
       id: version
       shell: bash
+      env:
+        BRANCH_NAME_WITH_REF: ${{ inputs.branch_name }}
+        VERSION_NUMBER: ${{ inputs.version_number }}
+        RELEASE_TYPE: ${{ inputs.type }}
+        WORKING_DIR: ${{ inputs.working_dir }}
       run: |
-        BRANCH_NAME_WITH_REF=${{ inputs.branch_name }}
         REF_PREFIX="refs/heads/"
         BRANCH_NAME=${BRANCH_NAME_WITH_REF#$REF_PREFIX}
         BRANCH_NAME_TRUNC=${BRANCH_NAME#50}
-        if [[ "${{ inputs.version_number }}" != "" ]]; then
-          echo "new_version=${{ inputs.version_number }}" >> $GITHUB_OUTPUT
-        elif [[ "${{ inputs.type }}" == "Snapshot" ]]; then
-          if [[ -f ${{ inputs.working_dir }}/pom.xml ]]; then
-            MVN_VERSION=$(grep -o '<version>.*</version>' ${{ inputs.working_dir }}/pom.xml | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
+        if [[ "${VERSION_NUMBER}" != "" ]]; then
+          echo "new_version=${VERSION_NUMBER}" >> $GITHUB_OUTPUT
+        elif [[ "${RELEASE_TYPE}" == "Snapshot" ]]; then
+          if [[ -f "${WORKING_DIR}/pom.xml" ]]; then
+            MVN_VERSION=$(grep -o '<version>.*</version>' "${WORKING_DIR}/pom.xml" | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
             IFS='.' read -r -a parts <<< "$MVN_VERSION"
             PATCH="${parts[2]}"
             PATCH=$(echo $PATCH | cut -d'-' -f 1)


### PR DESCRIPTION
Fixes 38 High-severity zizmor `template-injection` findings in `actions/run_e2e_tests` (26) and `actions/version_number` (12). Part of UID2-7011; sibling PRs: #249, #251.

**Fix pattern:** flagged `${{ inputs.* }}` expansions hoisted to step-level `env:` and referenced as quoted shell vars. Note the previous single-quote wrapping (`'${{ inputs.x }}'`) did **not** protect against injection — expansion precedes shell parsing, so a `'` in the value closes the quote. No behaviour change for benign values.

- **run_e2e_tests:** docker-run env plumbing now flows input → step `env:` → quoted shell var; step env names match the container env names so each line reads as a passthrough.
- **version_number:** `working_dir`, `branch_name`, `version_number`, `type` hoisted. `branch_name` is the important one — callers pass `github.ref`, so it's genuinely user-controlled, and it was an unquoted assignment.

**Verification:** `zizmor --offline --min-severity high` over both dirs exits 0 (was 38). Quoting audit in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
