### PR TITLE
UID2-7011: fix template-injection in remaining composite actions

### DIFF
--- a/actions/attest_image/action.yaml
+++ b/actions/attest_image/action.yaml
@@ -18,8 +18,12 @@ runs:
     - name: Lowercase image reference
       id: ref
       shell: bash
+      env:
+        # Passed via env rather than expanded into the script: caller-controlled
+        # input, expanding it inline is shell injection (zizmor: template-injection).
+        SUBJECT_NAME: ${{ inputs.subject_name }}
       run: |
-        value="$(printf '%s' '${{ inputs.subject_name }}' | tr '[:upper:]' '[:lower:]')"
+        value="$(printf '%s' "${SUBJECT_NAME}" | tr '[:upper:]' '[:lower:]')"
         echo "value=${value}" >> "$GITHUB_OUTPUT"
 
     - name: Attest build provenance
@@ -36,9 +40,11 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        SUBJECT_DIGEST: ${{ inputs.subject_digest }}
+        IMAGE_REF: ${{ steps.ref.outputs.value }}
       run: |
         # Accept either signer SAN: the reusable workflow under IABTechLab/uid2-shared-actions, or the caller's workflow via the composite path. --owner alone would reject the former (see https://github.com/cli/cli/issues/9045).
         gh attestation verify \
-          "oci://${{ steps.ref.outputs.value }}@${{ inputs.subject_digest }}" \
+          "oci://${IMAGE_REF}@${SUBJECT_DIGEST}" \
           --owner "${{ github.repository_owner }}" \
           --cert-identity-regex "^https://github\.com/(IABTechLab/uid2-shared-actions|${{ github.repository }})/"

--- a/actions/check_branch_and_release_type/action.yaml
+++ b/actions/check_branch_and_release_type/action.yaml
@@ -42,13 +42,22 @@ runs:
     - name: Fail if Pre-release on Default branch
       if: ${{ inputs.release_type == 'Snapshot' && github.event.repository.default_branch == github.ref_name }}
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        # Read via process.env rather than expanded into the script source:
+        # release_type is caller-controlled and the branch name is
+        # user-controlled, so template expansion inside the script is JS
+        # injection (zizmor: template-injection). GITHUB_REF_NAME is
+        # runner-provided.
+        RELEASE_TYPE: ${{ inputs.release_type }}
       with:
           script: |
-            core.setFailed('Snapshot packages can not be created on the default branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
+            core.setFailed(`Snapshot packages can not be created on the default branch. Release Type: ${process.env.RELEASE_TYPE}, Branch: ${process.env.GITHUB_REF_NAME}`)
 
     - name: Fail if Release and not on Default branch or release-yyyy-q branch
       if: ${{ inputs.release_type != 'Snapshot' && github.event.repository.default_branch != github.ref_name && !startsWith(github.ref_name, 'release')}}
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        RELEASE_TYPE: ${{ inputs.release_type }}
       with:
           script: |
-            core.setFailed('Releases can only be created on a Default or release-yyyy-q branch. Release Type: ${{ inputs.release_type }}, Branch: ${{ github.ref_name }}')
+            core.setFailed(`Releases can only be created on a Default or release-yyyy-q branch. Release Type: ${process.env.RELEASE_TYPE}, Branch: ${process.env.GITHUB_REF_NAME}`)

--- a/actions/commit_pr_and_merge/action.yaml
+++ b/actions/commit_pr_and_merge/action.yaml
@@ -133,14 +133,21 @@ runs:
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       if: steps.changes.outputs.changes_exist == 'true'
       id: create-pr
+      env:
+        # Passed via env and read with process.env rather than expanded into the
+        # script source: message is caller-controlled and github.ref_name is a
+        # user-controlled branch name, so template expansion inside the script
+        # is JS injection (zizmor: template-injection).
+        MESSAGE: ${{ inputs.message }}
+        BASE_BRANCH: ${{ inputs.base_branch == '' && github.ref_name || inputs.base_branch }}
       with:
         script: |
           const newPr = (await github.rest.pulls.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            title: '[CI Pipeline] ${{ inputs.message }}',
+            title: `[CI Pipeline] ${process.env.MESSAGE}`,
             head: '${{ steps.branch.outputs.name }}',
-            base: '${{ inputs.base_branch == '' && github.ref_name || inputs.base_branch }}',
+            base: process.env.BASE_BRANCH,
             body: '[CI Pipeline] Automated update'
           })).data;
           core.setOutput('pull-request-url', newPr.html_url);
@@ -186,6 +193,10 @@ runs:
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: tag-commit
       if: ${{ inputs.tag != '' && steps.changes.outputs.changes_exist == 'true' }}
+      env:
+        # Caller-controlled input, read via process.env to avoid JS injection
+        # (zizmor: template-injection).
+        TAG: ${{ inputs.tag }}
       with:
         script: |
           const pr = (await github.rest.pulls.get({
@@ -193,14 +204,14 @@ runs:
             repo: context.repo.repo,
             pull_number: ${{ steps.create-pr.outputs.pull-request-number }}
           })).data;
-          console.log(`Creating tag refs/tags/${{ inputs.tag }} pointing at commit SHA ${pr.merge_commit_sha}`);
+          console.log(`Creating tag refs/tags/${process.env.TAG} pointing at commit SHA ${pr.merge_commit_sha}`);
           await github.rest.git.createRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: 'refs/tags/${{ inputs.tag }}',
+            ref: `refs/tags/${process.env.TAG}`,
             sha: pr.merge_commit_sha
           });
-          core.setOutput('commit_tag', '${{ inputs.tag }}');
+          core.setOutput('commit_tag', process.env.TAG);
 
     - name: Get commit SHA
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/actions/prepare_gcp_metadata/action.yaml
+++ b/actions/prepare_gcp_metadata/action.yaml
@@ -52,9 +52,12 @@ runs:
     - name: Get image digest
       id: image_digest
       shell: bash
+      env:
+        # Passed via env rather than expanded into the script: caller-controlled
+        # input, expanding it inline is shell injection (zizmor: template-injection).
+        IMAGE_TAG: ${{ inputs.operator_image_version }}
       run: |
         IMAGE_NAME="us-docker.pkg.dev/uid2-prod-project/iabtechlab/uid2-operator"
-        IMAGE_TAG="${{ inputs.operator_image_version }}"
 
         # Pull the image to make sure it's available locally
         docker pull "${IMAGE_NAME}:${IMAGE_TAG}"

--- a/actions/shared_create_releases/action.yaml
+++ b/actions/shared_create_releases/action.yaml
@@ -234,9 +234,12 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        # Passed via env rather than expanded into the script: caller-controlled
+        # input, expanding it inline is shell injection (zizmor: template-injection).
+        NEW_VERSION: ${{ inputs.new_version }}
       run: |
         set -uo pipefail
-        tag="v${{ inputs.new_version }}"
+        tag="v${NEW_VERSION}"
         if gh api "repos/${{ github.repository }}/git/ref/tags/$tag" >/dev/null 2>&1; then
           echo "Verified release tag $tag exists."
         else

--- a/actions/shared_publish_to_docker/action.yaml
+++ b/actions/shared_publish_to_docker/action.yaml
@@ -74,8 +74,13 @@ runs:
     - name: Lowercase image reference
       id: imageRef
       shell: bash
+      env:
+        # Passed via env rather than expanded into the script: caller-controlled
+        # inputs, expanding them inline is shell injection (zizmor: template-injection).
+        DOCKER_REGISTRY: ${{ inputs.docker_registry }}
+        DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
       run: |
-        value="$(printf '%s' '${{ inputs.docker_registry }}/${{ inputs.docker_image_name }}' | tr '[:upper:]' '[:lower:]')"
+        value="$(printf '%s' "${DOCKER_REGISTRY}/${DOCKER_IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
         echo "value=${value}" >> "$GITHUB_OUTPUT"
 
     - name: Build and export to Docker

--- a/actions/update-major-version-tag/action.yaml
+++ b/actions/update-major-version-tag/action.yaml
@@ -17,10 +17,16 @@ runs:
     - name: Update major version tag
       id: updateTag
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        # Read via process.env rather than expanded into the script source:
+        # caller-controlled inputs inside a template literal are JS injection
+        # (zizmor: template-injection).
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_SHA: ${{ inputs.sha }}
       with:
         script: |
-          const inputVersion = `${{ inputs.version }}`;
-          const inputSha = `${{ inputs.sha }}`;
+          const inputVersion = process.env.INPUT_VERSION;
+          const inputSha = process.env.INPUT_SHA;
           const match = /^(v\d+)\.\d[\d\.]*$/.exec(inputVersion);
           if (match == null) {
               console.log('Unable to match a valid SEMVER string in input version.');


### PR DESCRIPTION
Fixes the remaining 28 High-severity zizmor `template-injection` findings across seven composite actions. With #249 and #250 merged, the repo hits zero High and the dogfood caller can flip to `fail_severity: high`.

**Fix patterns:**
- **Bash steps** — env-hoist + quoted shell vars (`attest_image`, `shared_publish_to_docker`, `shared_create_releases`, `prepare_gcp_metadata`).
- **github-script steps** — values read via `process.env.X` instead of expanded into the JS source (`commit_pr_and_merge` title/base/tag, `check_branch_and_release_type` failure messages, `update-major-version-tag` version/sha). Highest-value cluster: a `'` or backtick in a value previously became executable JS with the workflow's token. Branch name now comes from the runner's `GITHUB_REF_NAME`.

**Verification:** `zizmor --offline --min-severity high` over all seven dirs exits 0 (was 28). Quoting audit in the comment below.

**Scope note:** `artipacked` (the ticket's other rule) is deliberately not addressed here — Low/Medium severity (hidden at the `high` floor), no workflow uploads `.git` today, and its `persist-credentials: false` fix is a behaviour change (several workflows push release commits). Separate follow-up per the rollout plan on UID2-7011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
