### PR TITLE
UID2-7011: gate zizmor scan on High-severity findings

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -16,4 +16,6 @@ jobs:
   zizmor:
     uses: ./.github/workflows/shared-zizmor-scan.yaml
     with:
-      fail_severity: never   # report-only for now; set to `high` later to gate on High-severity
+      # Gate on High-severity findings: the repo reached zero High in PRs
+      # #249-#251, so a red check now means a genuine new High finding.
+      fail_severity: high


### PR DESCRIPTION
Flips the dogfood zizmor caller from report-only to blocking on High (`fail_severity: high`), per the rollout plan on UID2-7011.

Preconditions all met:
- #249, #250, #251 merged — full-repo `zizmor --min-severity high` on main exits 0 (was 95 findings)
- Fixes shipped to consumers in v3.95
- Release path canaried end-to-end: Snapshot publish on uid2-attestation-api ([run](https://github.com/IABTechLab/uid2-attestation-api/actions/runs/28630843266)) exercised version_number, check_branch_and_release_type, the maven workflow and the full commit_pr_and_merge PR/merge flow — all green

This PR is also its own proof: the zizmor check on it now runs with the gate on and only stays green if the repo is clean at High. A red zizmor check from here on means a genuine new High-severity finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)