### PR TITLE
UID2-7011: skip zizmor scan when there is nothing to scan

### DIFF
--- a/.github/workflows/shared-zizmor-scan.yaml
+++ b/.github/workflows/shared-zizmor-scan.yaml
@@ -9,15 +9,14 @@ on:
       min_severity:
         description: >-
           Lowest zizmor severity to report (informational|low|medium|high).
-          Precedence: this input if set, else the calling repo's `ZIZMOR_MIN_SEVERITY`
-          Actions variable, else `high` — the tier that maps to genuinely exploitable
-          findings in our estate (e.g. attacker-controllable template-injection).
-          Lower to `low`/`medium` to also surface defense-in-depth/hardening findings.
-          Prefer leaving this unset in callers: unset callers can be retuned centrally
-          (change the fallback here — ships to all `@v3` consumers) or per-repo with
-          no PR at all (set the repo variable).
+          Defaults to `high` — the tier that maps to genuinely exploitable findings
+          in our estate (e.g. attacker-controllable template-injection). Lower to
+          `low`/`medium` to also surface defense-in-depth/hardening findings.
+          Prefer leaving this unset in callers: bare callers inherit this default,
+          so the whole estate can be retuned by changing it here (ships to all
+          `@v3` consumers) without touching caller files.
         type: string
-        default: ''
+        default: 'high'
       min_confidence:
         description: >-
           Lowest zizmor confidence to report (low|medium|high). Keep at `low`:
@@ -29,13 +28,12 @@ on:
         description: >-
           Block (fail the job) on findings at or above this severity:
           never|informational|low|medium|high. Independent of the report floor.
-          Precedence: this input if set, else the calling repo's `ZIZMOR_FAIL_SEVERITY`
-          Actions variable, else `never` (non-blocking). Prefer leaving this unset in
-          callers: unset callers can be flipped to gating centrally (change the
-          fallback here — ships to all `@v3` consumers) or per-repo with no PR at all
-          (set the repo variable).
+          Defaults to `never` (non-blocking). Prefer leaving this unset in callers:
+          bare callers inherit this default, so gating can be introduced centrally
+          by changing it here (ships to all `@v3` consumers) without touching
+          caller files.
         type: string
-        default: ''
+        default: 'never'
       config:
         description: >-
           Path to a zizmor config file in the calling repo. NOTE: this FULLY
@@ -86,13 +84,9 @@ jobs:
         env:
           ZIZMOR_VERSION: ${{ inputs.zizmor_version }}
           SCAN_PATHS: ${{ inputs.scan_paths }}
-          # Report/gate floors resolve: explicit caller input > calling repo's
-          # ZIZMOR_* Actions variable (vars resolves against the repo the run
-          # belongs to, i.e. the caller) > central default. Central default and
-          # repo variable are both changeable without touching caller files.
-          MIN_SEVERITY: ${{ inputs.min_severity || vars.ZIZMOR_MIN_SEVERITY || 'high' }}
+          MIN_SEVERITY: ${{ inputs.min_severity }}
           MIN_CONFIDENCE: ${{ inputs.min_confidence }}
-          FAIL_SEVERITY: ${{ inputs.fail_severity || vars.ZIZMOR_FAIL_SEVERITY || 'never' }}
+          FAIL_SEVERITY: ${{ inputs.fail_severity }}
           CONFIG: ${{ inputs.config }}
         run: |
           set -euo pipefail

--- a/.github/workflows/shared-zizmor-scan.yaml
+++ b/.github/workflows/shared-zizmor-scan.yaml
@@ -9,11 +9,15 @@ on:
       min_severity:
         description: >-
           Lowest zizmor severity to report (informational|low|medium|high).
-          Defaults to `high` — the tier that maps to genuinely exploitable findings
-          in our estate (e.g. attacker-controllable template-injection). Lower to
-          `low`/`medium` to also surface defense-in-depth/hardening findings.
+          Precedence: this input if set, else the calling repo's `ZIZMOR_MIN_SEVERITY`
+          Actions variable, else `high` — the tier that maps to genuinely exploitable
+          findings in our estate (e.g. attacker-controllable template-injection).
+          Lower to `low`/`medium` to also surface defense-in-depth/hardening findings.
+          Prefer leaving this unset in callers: unset callers can be retuned centrally
+          (change the fallback here — ships to all `@v3` consumers) or per-repo with
+          no PR at all (set the repo variable).
         type: string
-        default: 'high'
+        default: ''
       min_confidence:
         description: >-
           Lowest zizmor confidence to report (low|medium|high). Keep at `low`:
@@ -25,9 +29,13 @@ on:
         description: >-
           Block (fail the job) on findings at or above this severity:
           never|informational|low|medium|high. Independent of the report floor.
-          Defaults to `never` (non-blocking). Set to `high` to gate on High only.
+          Precedence: this input if set, else the calling repo's `ZIZMOR_FAIL_SEVERITY`
+          Actions variable, else `never` (non-blocking). Prefer leaving this unset in
+          callers: unset callers can be flipped to gating centrally (change the
+          fallback here — ships to all `@v3` consumers) or per-repo with no PR at all
+          (set the repo variable).
         type: string
-        default: 'never'
+        default: ''
       config:
         description: >-
           Path to a zizmor config file in the calling repo. NOTE: this FULLY
@@ -75,9 +83,13 @@ jobs:
         env:
           ZIZMOR_VERSION: ${{ inputs.zizmor_version }}
           SCAN_PATHS: ${{ inputs.scan_paths }}
-          MIN_SEVERITY: ${{ inputs.min_severity }}
+          # Report/gate floors resolve: explicit caller input > calling repo's
+          # ZIZMOR_* Actions variable (vars resolves against the repo the run
+          # belongs to, i.e. the caller) > central default. Central default and
+          # repo variable are both changeable without touching caller files.
+          MIN_SEVERITY: ${{ inputs.min_severity || vars.ZIZMOR_MIN_SEVERITY || 'high' }}
           MIN_CONFIDENCE: ${{ inputs.min_confidence }}
-          FAIL_SEVERITY: ${{ inputs.fail_severity }}
+          FAIL_SEVERITY: ${{ inputs.fail_severity || vars.ZIZMOR_FAIL_SEVERITY || 'never' }}
           CONFIG: ${{ inputs.config }}
         run: |
           set -euo pipefail

--- a/.github/workflows/shared-zizmor-scan.yaml
+++ b/.github/workflows/shared-zizmor-scan.yaml
@@ -53,6 +53,9 @@ on:
           they live) are covered too — not just `.github/workflows`. zizmor honors
           `.gitignore` when collecting inputs. Ensure the caller's trigger `paths`
           cover everywhere scannable files live, or changes can slip through.
+          With the default `.`, a repo with no scannable files skips green
+          (legitimate for ruleset-injected runs); with explicit paths, an empty
+          collection fails closed (probable typo).
         type: string
         default: '.'
       zizmor_version:
@@ -133,12 +136,32 @@ jobs:
           set -e
 
           # Fail hard on anything that isn't a clean run (0) or a findings run
-          # (11-14). An errored or empty scan (bad scan_paths, install failure, arg
-          # error) must NOT pass silently under fail_severity: never — for a security
-          # control, fail-open is the worst outcome. Dump both streams so the real
-          # cause is visible.
+          # (11-14). An errored scan (install failure, arg error) must NOT pass
+          # silently under fail_severity: never — for a security control,
+          # fail-open is the worst outcome. Dump both streams so the real cause
+          # is visible.
+          #
+          # Exit 3 ("no inputs collected") splits by intent: when scanning the
+          # default '.', it just means the repo has no GitHub Actions content —
+          # legitimate for ruleset-injected runs that target every repo, so skip
+          # green with a notice. When the caller set scan_paths explicitly, an
+          # empty collection is more likely a typo'd path, so keep failing closed.
           case "${code}" in
             0|11|12|13|14) : ;;
+            3)
+              if [ "${SCAN_PATHS}" = "." ]; then
+                echo "No GitHub Actions workflows or composite actions in this repo; nothing to scan."
+                {
+                  echo "## 🌈 zizmor — GitHub Actions security scan"
+                  echo ""
+                  echo "Nothing to scan: this repo has no GitHub Actions workflows or composite actions. Skipped."
+                } >> "${GITHUB_STEP_SUMMARY}"
+                exit 0
+              fi
+              echo "zizmor collected no inputs from scan_paths='${SCAN_PATHS}' (exit 3); failing."
+              cat zizmor.log report.txt
+              exit 1
+              ;;
             *)
               echo "zizmor did not complete a scan (exit ${code}); failing."
               cat zizmor.log report.txt

--- a/.github/workflows/shared-zizmor-scan.yaml
+++ b/.github/workflows/shared-zizmor-scan.yaml
@@ -12,7 +12,6 @@ on:
           Defaults to `high` — the tier that maps to genuinely exploitable findings
           in our estate (e.g. attacker-controllable template-injection). Lower to
           `low`/`medium` to also surface defense-in-depth/hardening findings.
-          Leave unset in callers so this default stays the single tuning point.
         type: string
         default: 'high'
       min_confidence:
@@ -26,8 +25,7 @@ on:
         description: >-
           Block (fail the job) on findings at or above this severity:
           never|informational|low|medium|high. Independent of the report floor.
-          Defaults to `never` (non-blocking). Leave unset in callers so gating
-          can be introduced by changing this default.
+          Defaults to `never` (non-blocking).
         type: string
         default: 'never'
       config:

--- a/.github/workflows/shared-zizmor-scan.yaml
+++ b/.github/workflows/shared-zizmor-scan.yaml
@@ -124,24 +124,19 @@ jobs:
 
           # Fail hard on anything that isn't a clean run (0) or a findings run
           # (11-14): an errored scan must not pass silently under
-          # fail_severity: never. Exception: exit 3 ("no inputs collected") on
-          # the default '.' scan means the repo has no Actions content — skip
-          # green; with explicit scan_paths it's more likely a typo — fail.
+          # fail_severity: never. Exception: exit 3 ("no inputs collected",
+          # reason verified from the log) on the default '.' scan means the
+          # repo has no Actions content — it flows through the normal summary
+          # and gate as a skip; with explicit scan_paths it's more likely a
+          # typo — fail.
           case "${code}" in
             0|11|12|13|14) : ;;
             3)
-              if [ "${SCAN_PATHS}" = "." ]; then
-                echo "No GitHub Actions workflows or composite actions in this repo; nothing to scan."
-                {
-                  echo "## 🌈 zizmor — GitHub Actions security scan"
-                  echo ""
-                  echo "Nothing to scan: this repo has no GitHub Actions workflows or composite actions. Skipped."
-                } >> "${GITHUB_STEP_SUMMARY}"
-                exit 0
+              if [ "${SCAN_PATHS}" != "." ] || ! grep -q 'no inputs collected' zizmor.log; then
+                echo "zizmor collected no inputs from scan_paths='${SCAN_PATHS}' (exit 3); failing."
+                cat zizmor.log report.txt
+                exit 1
               fi
-              echo "zizmor collected no inputs from scan_paths='${SCAN_PATHS}' (exit 3); failing."
-              cat zizmor.log report.txt
-              exit 1
               ;;
             *)
               echo "zizmor did not complete a scan (exit ${code}); failing."
@@ -162,6 +157,7 @@ jobs:
           # Job summary: status line + scan evidence + report/log (collapsed).
           case "${code}" in
             0)  status="✅ no findings at or above '${MIN_SEVERITY}'." ;;
+            3)  status="nothing to scan: no GitHub Actions workflows or composite actions in this repo — skipped." ;;
             14) status="findings present — highest severity: High." ;;
             13) status="findings present — highest severity: Medium." ;;
             12) status="findings present — highest severity: Low." ;;
@@ -181,7 +177,7 @@ jobs:
             echo "| confidence floor | \`${MIN_CONFIDENCE}\` |"
             echo "| rule config | ${config_desc} |"
             echo "| gate | $([ "${FAIL_SEVERITY}" = "never" ] && echo "report-only" || echo "block on \`${FAIL_SEVERITY}\`+") |"
-            if [ "${code}" -ne 0 ]; then
+            if [ "${code}" -ge 11 ]; then
               echo ""
               echo "<details><summary>Findings</summary>"
               echo ""

--- a/.github/workflows/shared-zizmor-scan.yaml
+++ b/.github/workflows/shared-zizmor-scan.yaml
@@ -12,9 +12,7 @@ on:
           Defaults to `high` — the tier that maps to genuinely exploitable findings
           in our estate (e.g. attacker-controllable template-injection). Lower to
           `low`/`medium` to also surface defense-in-depth/hardening findings.
-          Prefer leaving this unset in callers: bare callers inherit this default,
-          so the whole estate can be retuned by changing it here (ships to all
-          `@v3` consumers) without touching caller files.
+          Leave unset in callers so this default stays the single tuning point.
         type: string
         default: 'high'
       min_confidence:
@@ -28,10 +26,8 @@ on:
         description: >-
           Block (fail the job) on findings at or above this severity:
           never|informational|low|medium|high. Independent of the report floor.
-          Defaults to `never` (non-blocking). Prefer leaving this unset in callers:
-          bare callers inherit this default, so gating can be introduced centrally
-          by changing it here (ships to all `@v3` consumers) without touching
-          caller files.
+          Defaults to `never` (non-blocking). Leave unset in callers so gating
+          can be introduced by changing this default.
         type: string
         default: 'never'
       config:
@@ -51,9 +47,8 @@ on:
           they live) are covered too — not just `.github/workflows`. zizmor honors
           `.gitignore` when collecting inputs. Ensure the caller's trigger `paths`
           cover everywhere scannable files live, or changes can slip through.
-          With the default `.`, a repo with no scannable files skips green
-          (legitimate for ruleset-injected runs); with explicit paths, an empty
-          collection fails closed (probable typo).
+          With the default `.` an empty repo skips green; with explicit paths an
+          empty scan fails closed.
         type: string
         default: '.'
       zizmor_version:
@@ -130,16 +125,10 @@ jobs:
           set -e
 
           # Fail hard on anything that isn't a clean run (0) or a findings run
-          # (11-14). An errored scan (install failure, arg error) must NOT pass
-          # silently under fail_severity: never — for a security control,
-          # fail-open is the worst outcome. Dump both streams so the real cause
-          # is visible.
-          #
-          # Exit 3 ("no inputs collected") splits by intent: when scanning the
-          # default '.', it just means the repo has no GitHub Actions content —
-          # legitimate for ruleset-injected runs that target every repo, so skip
-          # green with a notice. When the caller set scan_paths explicitly, an
-          # empty collection is more likely a typo'd path, so keep failing closed.
+          # (11-14): an errored scan must not pass silently under
+          # fail_severity: never. Exception: exit 3 ("no inputs collected") on
+          # the default '.' scan means the repo has no Actions content — skip
+          # green; with explicit scan_paths it's more likely a typo — fail.
           case "${code}" in
             0|11|12|13|14) : ;;
             3)

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -14,6 +14,5 @@ permissions:
 
 jobs:
   zizmor:
-    # Bare call: severity floors inherit from the shared workflow's central
-    # defaults (report-only, High), so org-wide retunes are a single change there.
+    # Bare call: severity floors come from the shared workflow's defaults.
     uses: ./.github/workflows/shared-zizmor-scan.yaml

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -15,6 +15,5 @@ permissions:
 jobs:
   zizmor:
     # Bare call: severity floors inherit from the shared workflow's central
-    # defaults (report-only, High) and can be overridden per-repo via the
-    # ZIZMOR_MIN_SEVERITY / ZIZMOR_FAIL_SEVERITY Actions variables — no PR needed.
+    # defaults (report-only, High), so org-wide retunes are a single change there.
     uses: ./.github/workflows/shared-zizmor-scan.yaml

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   zizmor:
+    # Bare call: severity floors inherit from the shared workflow's central
+    # defaults (report-only, High) and can be overridden per-repo via the
+    # ZIZMOR_MIN_SEVERITY / ZIZMOR_FAIL_SEVERITY Actions variables — no PR needed.
     uses: ./.github/workflows/shared-zizmor-scan.yaml
-    with:
-      fail_severity: never   # report-only for now; set to `high` later to gate on High-severity

--- a/README.md
+++ b/README.md
@@ -65,12 +65,6 @@ jobs:
     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-zizmor-scan.yaml@v3
 ```
 
-Keep the caller **bare** (no `with:`) so the severity floors stay centrally
-controllable: an explicit `with:` input pins a repo (and needs a per-repo PR to
-change), while bare callers inherit the central defaults in
-`shared-zizmor-scan.yaml` (report floor `high`, gate `never`) — one PR here
-retunes every bare caller via `@v3`.
-
 For one-off false positives in a consuming repo, add an inline
 `# zizmor: ignore[<rule>]` comment on the offending line. See the workflow's input
 descriptions for `min_severity`, `min_confidence`, `fail_severity`, and `config`.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ The marker goes in the commit message, not the branch name or PR title. This is 
 `shared-zizmor-scan.yaml` runs [zizmor](https://docs.zizmor.sh) over a repo's GitHub
 Actions workflows to catch workflow-security issues.
 By default it runs all offline zizmor rules except `unpinned-uses` (disabled in
-config — SHA-pinning was declined for UID2), reports **High-severity** findings
-(`min_severity`), and is non-blocking (`fail_severity: never`).
+config — SHA-pinning was declined for UID2), reports **High-severity** findings,
+and is non-blocking.
 
 Adopt it by adding a small caller workflow to the target repo:
 
@@ -63,9 +63,16 @@ permissions:
 jobs:
   zizmor:
     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-zizmor-scan.yaml@v3
-    with:
-      fail_severity: never   # report-only; set to `high` to block PRs on High-severity findings
 ```
+
+Keep the caller **bare** (no `with:`) so the severity floors stay centrally
+controllable. Three levers, in precedence order:
+
+1. **Explicit `with:` input** in the caller — per-repo pin, needs a PR to change.
+2. **Repo Actions variables** `ZIZMOR_MIN_SEVERITY` / `ZIZMOR_FAIL_SEVERITY` — per-repo
+   override with no PR (`gh variable set ZIZMOR_FAIL_SEVERITY -b high -R <repo>`).
+3. **Central defaults** in `shared-zizmor-scan.yaml` (report floor `high`, gate
+   `never`) — one PR here retunes every bare caller via `@v3`.
 
 For one-off false positives in a consuming repo, add an inline
 `# zizmor: ignore[<rule>]` comment on the offending line. See the workflow's input

--- a/README.md
+++ b/README.md
@@ -66,13 +66,10 @@ jobs:
 ```
 
 Keep the caller **bare** (no `with:`) so the severity floors stay centrally
-controllable. Three levers, in precedence order:
-
-1. **Explicit `with:` input** in the caller — per-repo pin, needs a PR to change.
-2. **Repo Actions variables** `ZIZMOR_MIN_SEVERITY` / `ZIZMOR_FAIL_SEVERITY` — per-repo
-   override with no PR (`gh variable set ZIZMOR_FAIL_SEVERITY -b high -R <repo>`).
-3. **Central defaults** in `shared-zizmor-scan.yaml` (report floor `high`, gate
-   `never`) — one PR here retunes every bare caller via `@v3`.
+controllable: an explicit `with:` input pins a repo (and needs a per-repo PR to
+change), while bare callers inherit the central defaults in
+`shared-zizmor-scan.yaml` (report floor `high`, gate `never`) — one PR here
+retunes every bare caller via `@v3`.
 
 For one-off false positives in a consuming repo, add an inline
 `# zizmor: ignore[<rule>]` comment on the offending line. See the workflow's input


### PR DESCRIPTION
Makes a repo with nothing to scan pass instead of fail, so the scan can be applied blanket-style (e.g. the UnifiedID2 required-workflow ruleset targeting `~ALL` repos).

zizmor exit 3 ("no inputs collected") now splits by intent:
- default `scan_paths: '.'` → the repo genuinely has no GitHub Actions content → **skip green** with a summary notice
- explicit `scan_paths` → an empty collection is a probable typo → **fail closed**, as before

Verified empirically that a repo with no Actions content yields exit 3; actionlint + zizmor self-scan clean.

Also makes this repo's own caller bare (severity floors inherit the shared defaults — same effective values) and drops the `with:` line from the README adoption example.

Must merge **and ship in a v3 release** before uid2-okta-configuration#222 applies, since the ruleset-injected workflow calls `@v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
