### PR TITLE
UID2-7482: pin AKS E2E az to Python 3.13 build (Azure/azure-cli#32869)

### DIFF
--- a/.github/workflows/shared-run-e2e-tests.yaml
+++ b/.github/workflows/shared-run-e2e-tests.yaml
@@ -76,6 +76,10 @@ on:
 env:
   REGISTRY: ghcr.io
 
+  # Last azure-cli built on Python 3.13; works around the Python 3.14 az deadlock
+  # (Azure/azure-cli#32869). Bump or remove once azure-cli supports Python 3.14.
+  AZURE_CLI_PINNED_VERSION: "2.87.0"
+
   E2E_UID2_INTEG_GCP_ARGS_JSON: ${{ secrets.E2E_UID2_INTEG_GCP_ARGS_JSON }}
   E2E_UID2_INTEG_AWS_ARGS_JSON: ${{ secrets.E2E_UID2_INTEG_AWS_ARGS_JSON }}
   E2E_UID2_INTEG_AZURE_ARGS_JSON: ${{ secrets.E2E_UID2_INTEG_AZURE_ARGS_JSON }}
@@ -203,6 +207,12 @@ jobs:
           identity_scope: ${{ inputs.identity_scope }}
           target_environment: ${{ inputs.target_environment }}
           aws_pcr0: ${{ inputs.aws_pcr0 }}
+
+      - name: Pin Azure CLI (Azure/azure-cli#32869)
+        if: ${{ inputs.operator_type == 'aks' }}
+        uses: IABTechLab/uid2-shared-actions/actions/pin_azure_cli@v3
+        with:
+          azure_cli_version: ${{ env.AZURE_CLI_PINNED_VERSION }}
 
       - name: Start AKS cluster
         id: start_aks_cluster
@@ -403,6 +413,12 @@ jobs:
         with:
           aws_stack_name: ${{ needs.e2e-test.outputs.aws_stack_name }}
           aws_region: ${{ inputs.aws_region }}
+
+      - name: Pin Azure CLI (Azure/azure-cli#32869)
+        if: ${{ inputs.operator_type == 'aks' }}
+        uses: IABTechLab/uid2-shared-actions/actions/pin_azure_cli@v3
+        with:
+          azure_cli_version: ${{ env.AZURE_CLI_PINNED_VERSION }}
 
       - name: Stop AKS private operator
         if: ${{ inputs.operator_type == 'aks' }}

--- a/actions/pin_azure_cli/action.yaml
+++ b/actions/pin_azure_cli/action.yaml
@@ -1,0 +1,29 @@
+name: Pin Azure CLI
+description: >
+  Pin the runner's Azure CLI to a specific version via apt (downgrading if
+  needed), so az runs on the Python interpreter that version bundles. Works
+  around Azure/azure-cli#32869: on Python 3.14, msal's lazy `import requests` on
+  the CLI's long-running-operation poller thread deadlocks
+  (_frozen_importlib._DeadlockError) and crashes commands such as
+  `az network vnet create`, `az aks create`, and `az group delete`. Pin to a
+  build on Python <= 3.13 until upstream ships Python 3.14 support.
+
+inputs:
+  azure_cli_version:
+    description: azure-cli version to pin; that version's apt build is installed, e.g. "2.87.0".
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Pin azure-cli
+      shell: bash
+      env:
+        AZURE_CLI_VERSION: ${{ inputs.azure_cli_version }}
+      run: |
+        : "${AZURE_CLI_VERSION:?azure_cli_version input is required}"
+        # Idempotent: a no-op when az is already at the pinned version. The glob
+        # matches the -1~<dist> apt revision so it need not be spelled out.
+        pkg="azure-cli=${AZURE_CLI_VERSION}*"
+        sudo apt-get update
+        sudo apt-get install -y --allow-downgrades "${pkg}"


### PR DESCRIPTION
Fixes the deterministic failure of the Azure AKS E2E job — `az network vnet create` / `az group delete` crash with `_frozen_importlib._DeadlockError`.

**Cause:** the runner's `az` (azure-cli 2.88.0) runs on Python 3.14, where msal's lazy `import requests` on the CLI's long-running-operation poller thread deadlocks. Upstream [Azure/azure-cli#32869](https://github.com/Azure/azure-cli/issues/32869) — Python 3.14 not yet supported.

**Fix:** pin the runner's apt `az` to 2.87.0 (last build on Python 3.13) via a new `pin_azure_cli` composite action, invoked in both AKS jobs — `e2e-test` (before Start AKS cluster) and `e2e-test-cleanup` (before Stop AKS private operator, which runs on its own runner). The pinned version is one workflow env var. `aks_env.sh` is unchanged.

**Verification:** takes effect once merged and the `v3` tag is moved to include it; confirm with a scheduled/manual *Publish All Operators* run.

Revert (action + two steps + env var) once azure-cli supports Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)