### PR TITLE
UID2-7589: bump AKS E2E Kubernetes version from 1.33 to 1.36

### DIFF
--- a/scripts/aks/start_aks_cluster.sh
+++ b/scripts/aks/start_aks_cluster.sh
@@ -61,11 +61,13 @@ if az aks show --resource-group ${RESOURCE_GROUP} --name ${AKS_CLUSTER_NAME} &>/
   echo "AKS cluster '${AKS_CLUSTER_NAME}' already exists, skipping creation."
 else
   echo "Creating AKS cluster '${AKS_CLUSTER_NAME}'..."
+  # AKS drops each minor version to LTS-only ~12 months after GA, and cluster
+  # creation then fails with K8sVersionNotSupported. Bump before Jun 2027.
   az aks create \
       --resource-group ${RESOURCE_GROUP} \
       --name ${AKS_CLUSTER_NAME} \
       --location ${LOCATION} \
-      --kubernetes-version 1.33 \
+      --kubernetes-version 1.36 \
       --network-plugin azure \
       --network-policy calico \
       --vnet-subnet-id ${AKS_SUBNET_ID} \


### PR DESCRIPTION
## What

Bumps the hardcoded `--kubernetes-version` in `scripts/aks/start_aks_cluster.sh` from `1.33` to `1.36`.

## Why

The nightly scheduled `Publish All Operators` workflow in `uid2-operator` has failed on 2026-07-28 and 2026-07-29 in the `Azure Private Operator / E2E Azure AKS / E2E Test` job, at the `Start AKS cluster` step. Every other job in the pipeline passes — the failure is isolated to AKS cluster creation:

```
ERROR: (K8sVersionNotSupported) Managed cluster opr-e2e-cluster-10737571 is on version
1.33.13, which is only available for Long-Term Support (LTS). To enable LTS on the
cluster, see https://aka.ms/aks/enable-lts. Otherwise, use [az aks get-versions] command
to get the supported version list in this region.
Code: K8sVersionNotSupported
```

AKS gives each minor version 12 months of standard support after GA. 1.33 went GA in Jun 2025 and reached **end of life in Jul 2026** — i.e. right now — so it has dropped to LTS-only and `az aks create` rejects it outright. Nothing changed on our side; this is Azure's support calendar catching up with a stale pin.

## Why 1.36 and not 1.34

Per the [AKS supported versions calendar](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions):

| Version | AKS GA | End of life |
| --- | --- | --- |
| 1.33 | Jun 2025 | Jul 2026 (now LTS-only) |
| 1.34 | Nov 2025 | Nov 2026 |
| 1.35 | Mar 2026 | Mar 2027 |
| **1.36** | **Jun 2026** | **Jun 2027** |
| 1.37 | Oct 2026 | not yet GA |

1.34 is the smallest bump but expires in ~4 months, which would reintroduce this exact failure almost immediately. 1.36 is the latest GA release and buys ~11 months.

## Risk

Low. The E2E cluster is created fresh per workflow run (`opr-e2e-cluster-<run-id>`) and torn down afterwards, so there is no in-place cluster upgrade to coordinate and no persistent state to migrate. This is the only hardcoded occurrence of the Kubernetes version across `uid2-shared-actions` and `uid2-operator`. CI-only change — no client-facing impact.

The remaining `az aks create` flags (`--network-plugin azure`, `--network-policy calico`, `--node-vm-size Standard_D4d_v5`, `--auto-upgrade-channel patch`, `--os-sku Ubuntu`) are all still valid on 1.36. Note `--auto-upgrade-channel patch` only tracks patches *within* a minor, so it does not protect against minor-version retirement — hence the pin still needs periodic bumping, which the added comment records.

## Considered and rejected

Resolving the version dynamically from `az aks get-versions` would be self-healing, but makes the E2E Kubernetes version shift between runs, which undermines reproducibility when debugging an operator failure. Keeping a deterministic pin with an explicit expiry note was preferred.

## Testing

- `bash -n scripts/aks/start_aks_cluster.sh` passes.
- Real verification is a green `Azure Private Operator / E2E Azure AKS / E2E Test` job — will confirm against a run of `Publish All Operators` once this merges, since the workflow consumes this script from the default branch.

Ticket: [UID2-7589](https://thetradedesk.atlassian.net/browse/UID2-7589)

🤖 Generated with [Claude Code](https://claude.com/claude-code)