### PR TITLE
UID2-7648: emit Trivy JSON reports alongside the existing tables

### DIFF
--- a/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
@@ -97,6 +97,21 @@ jobs:
             JAR_VERSION=${{ steps.package.outputs.jar_version }}
             IMAGE_VERSION=${{ steps.package.outputs.jar_version }}-${{ steps.package.outputs.git_commit }}
 
+      # A caller can matrix over Dockerfiles, and every leg shares github.job and github.sha —
+      # so the Dockerfile is the only thing that keeps the tag, and the scan artifacts named
+      # after it, distinct. Sanitised because tags reject '/' and must start alphanumeric.
+      - name: Derive a unique image tag
+        if: inputs.scan_type == 'image' && inputs.dockerfile != ''
+        id: imageScanTag
+        shell: bash
+        env:
+          # Passed via env rather than expanded into the script: caller-controlled
+          # input, expanding it inline is shell injection (zizmor: template-injection).
+          DOCKERFILE: ${{ inputs.dockerfile }}
+        run: |
+          slug=$(printf '%s' "$DOCKERFILE" | sed 's/[^A-Za-z0-9._-]/-/g; s/^[^A-Za-z0-9_]*//')
+          echo "value=image-scan:${slug}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
       # Non-Maven path: build the supplied Dockerfile directly (re-pulls its base image each run).
       - name: Build Docker image from Dockerfile
         if: inputs.scan_type == 'image' && inputs.dockerfile != ''
@@ -105,7 +120,7 @@ jobs:
           context: ${{ inputs.working_dir }}
           file: ${{ inputs.dockerfile }}
           load: true
-          tags: image-scan:${{ github.sha }}
+          tags: ${{ steps.imageScanTag.outputs.value }}
 
       - name: Vulnerability Scan
         id: vulnerability-scan
@@ -114,7 +129,7 @@ jobs:
           scan_severity: ${{ inputs.vulnerability_severity }}
           failure_severity: ${{ inputs.vulnerability_severity }}
           publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
-          image_ref: ${{ inputs.dockerfile != '' && format('image-scan:{0}', github.sha) || steps.meta.outputs.tags }}
+          image_ref: ${{ inputs.dockerfile != '' && steps.imageScanTag.outputs.value || steps.meta.outputs.tags }}
           scan_type: ${{ inputs.scan_type }}
         continue-on-error: true
 

--- a/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
@@ -109,7 +109,8 @@ jobs:
 
       - name: Vulnerability Scan
         id: vulnerability-scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
+        # TEMPORARY (UID2-7648): pinned to the branch to exercise the new action. Revert to @v3.
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@swi-UID2-7648-trivy-json-output
         with:
           scan_severity: ${{ inputs.vulnerability_severity }}
           failure_severity: ${{ inputs.vulnerability_severity }}

--- a/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/shared-vulnerability-scan-failure-notify.yaml
@@ -109,8 +109,7 @@ jobs:
 
       - name: Vulnerability Scan
         id: vulnerability-scan
-        # TEMPORARY (UID2-7648): pinned to the branch to exercise the new action. Revert to @v3.
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@swi-UID2-7648-trivy-json-output
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:
           scan_severity: ${{ inputs.vulnerability_severity }}
           failure_severity: ${{ inputs.vulnerability_severity }}

--- a/.github/workflows/vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/vulnerability-scan-failure-notify.yaml
@@ -16,7 +16,8 @@ on:
 
 jobs:
   vulnerability-scan-failure-notify:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@v3
+    # TEMPORARY (UID2-7648): pinned to the branch to exercise the new action. Revert to @v3.
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@swi-UID2-7648-trivy-json-output
     secrets:
       SLACK_WEBHOOK : ${{ secrets.SLACK_WEBHOOK }}
     with:

--- a/.github/workflows/vulnerability-scan-failure-notify.yaml
+++ b/.github/workflows/vulnerability-scan-failure-notify.yaml
@@ -16,8 +16,7 @@ on:
 
 jobs:
   vulnerability-scan-failure-notify:
-    # TEMPORARY (UID2-7648): pinned to the branch to exercise the new action. Revert to @v3.
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@swi-UID2-7648-trivy-json-output
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-vulnerability-scan-failure-notify.yaml@v3
     secrets:
       SLACK_WEBHOOK : ${{ secrets.SLACK_WEBHOOK }}
     with:

--- a/actions/vulnerability_scan/action.yaml
+++ b/actions/vulnerability_scan/action.yaml
@@ -78,22 +78,37 @@ runs:
       path: ${{ github.workspace }}/.cache/trivy
       key: cache-trivy-${{ steps.date.outputs.date }}
 
+  # Scanned once; every format below is rendered from this JSON by `trivy convert`.
+  # Severity must stay a superset of every floor rendered below — `convert` only filters down,
+  # and silently: a missing severity renders as "MEDIUM: 0", not an error.
   - name: Generate Trivy vulnerability scan report
     uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-    if: inputs.publish_vulnerabilities == 'true'
     with:
       image-ref: ${{ inputs.image_ref }}
       scan-type: ${{ inputs.scan_type }}
       skip-files: ${{ inputs.skip_files }}
-      format: 'sarif'
+      format: 'json'
       exit-code: '0'
       ignore-unfixed: false
-      severity: ${{ inputs.scan_severity }}
-      output: 'trivy-results.sarif'
+      severity: 'MEDIUM,HIGH,CRITICAL'
+      output: 'trivy-results.json'
       hide-progress: true
     env:
       TRIVY_SKIP_DB_UPDATE: true
       TRIVY_SKIP_JAVA_DB_UPDATE: true
+
+  # trivy is on PATH from the scan step (setup-trivy adds it to $GITHUB_PATH).
+  # --scanners must match what the scan ran, or the summary table is silently dropped.
+  - name: Render SARIF report
+    if: inputs.publish_vulnerabilities == 'true'
+    shell: bash
+    env:
+      # Passed via env rather than expanded into the script: caller-controlled
+      # input, expanding it inline is shell injection (zizmor: template-injection).
+      SCAN_SEVERITY: ${{ inputs.scan_severity }}
+    run: |
+      trivy convert --scanners vuln,secret --format sarif \
+        --severity "${SCAN_SEVERITY}" --output trivy-results.sarif trivy-results.json
 
   - name: Upload Trivy scan report to GitHub Security tab
     uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
@@ -101,34 +116,63 @@ runs:
     with:
       sarif_file: 'trivy-results.sarif'
 
+  # Names must be unique per run, and github.job is not: buildPublic and buildGCP both reach
+  # this action through a reusable workflow whose job is `buildImage`. The scan target splits them.
+  - name: Name the report artifacts
+    id: reportName
+    shell: bash
+    env:
+      # Passed via env rather than expanded into the script: caller-controlled
+      # inputs, expanding them inline is shell injection (zizmor: template-injection).
+      IMAGE_REF: ${{ inputs.image_ref }}
+      SCAN_TYPE: ${{ inputs.scan_type }}
+      JOB: ${{ github.job }}
+    run: |
+      target="${IMAGE_REF:-$SCAN_TYPE}"
+      target="${target//[^A-Za-z0-9._-]/-}"      # artifact names reject :/\<>|*?"
+      echo "value=trivy-report-${JOB}-${target}" >> "$GITHUB_OUTPUT"
+      echo "gate=trivy-gate-${JOB}-${target}" >> "$GITHUB_OUTPUT"
+
+  # Machine-readable copy, so triage tooling need not parse the table out of the job log.
+  - name: Upload Trivy JSON report
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    with:
+      name: ${{ steps.reportName.outputs.value }}
+      path: trivy-results.json
+      retention-days: 30
+      overwrite: true
+
+  # Only what fails the build, without the package inventory. failure_severity is applied here
+  # because it is not recorded in the report, so a consumer cannot re-derive it.
+  - name: Render gate-scoped JSON report
+    shell: bash
+    env:
+      # See note on SCAN_SEVERITY above.
+      FAILURE_SEVERITY: ${{ inputs.failure_severity }}
+    run: |
+      trivy convert --scanners vuln,secret --format json --severity "${FAILURE_SEVERITY}" \
+        --list-all-pkgs=false --output trivy-gate.json trivy-results.json
+
+  - name: Upload gate-scoped JSON report
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    with:
+      name: ${{ steps.reportName.outputs.gate }}
+      path: trivy-gate.json
+      retention-days: 30
+      overwrite: true
+
   - name: Local vulnerability scanner for MEDIUM,HIGH,CRITICAL for reporting
     if: ${{ inputs.full_report  == 'true' }}
-    uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-    with:
-      image-ref: ${{ inputs.image_ref }}
-      scan-type: ${{ inputs.scan_type }}
-      skip-files: ${{ inputs.skip_files }}
-      format: 'table'
-      exit-code: '0'
-      ignore-unfixed: false
-      severity: 'MEDIUM,HIGH,CRITICAL'
-      hide-progress: true
-    env:
-      TRIVY_SKIP_DB_UPDATE: true
-      TRIVY_SKIP_JAVA_DB_UPDATE: true
-      TRIVY_DEPENDENCY_TREE: true
+    shell: bash
+    run: |
+      trivy convert --scanners vuln,secret --format table --dependency-tree \
+        --severity 'MEDIUM,HIGH,CRITICAL' trivy-results.json
 
   - name: Test with Trivy vulnerability scanner
-    uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-    with:
-      image-ref: ${{ inputs.image_ref }}
-      scan-type: ${{ inputs.scan_type }}
-      skip-files: ${{ inputs.skip_files }}
-      format: 'table'
-      exit-code: '1'
-      ignore-unfixed: false
-      severity: ${{ inputs.failure_severity }}
-      hide-progress: true
+    shell: bash
     env:
-      TRIVY_SKIP_DB_UPDATE: true
-      TRIVY_SKIP_JAVA_DB_UPDATE: true
+      # See note on SCAN_SEVERITY above.
+      FAILURE_SEVERITY: ${{ inputs.failure_severity }}
+    run: |
+      trivy convert --scanners vuln,secret --format table \
+        --severity "${FAILURE_SEVERITY}" --exit-code 1 trivy-results.json

--- a/actions/vulnerability_scan/action.yaml
+++ b/actions/vulnerability_scan/action.yaml
@@ -78,9 +78,8 @@ runs:
       path: ${{ github.workspace }}/.cache/trivy
       key: cache-trivy-${{ steps.date.outputs.date }}
 
-  # Scanned once; every format below is rendered from this JSON by `trivy convert`.
-  # Severity must stay a superset of every floor rendered below — `convert` only filters down,
-  # and silently: a missing severity renders as "MEDIUM: 0", not an error.
+  # Scan for all severities and export a JSON file which is used in subsequent steps
+  # to produce outputs
   - name: Generate Trivy vulnerability scan report
     uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
     with:
@@ -90,21 +89,18 @@ runs:
       format: 'json'
       exit-code: '0'
       ignore-unfixed: false
-      severity: 'MEDIUM,HIGH,CRITICAL'
+      severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
       output: 'trivy-results.json'
       hide-progress: true
     env:
       TRIVY_SKIP_DB_UPDATE: true
       TRIVY_SKIP_JAVA_DB_UPDATE: true
 
-  # trivy is on PATH from the scan step (setup-trivy adds it to $GITHUB_PATH).
-  # --scanners must match what the scan ran, or the summary table is silently dropped.
-  - name: Render SARIF report
+  - name: Create SARIF report
     if: inputs.publish_vulnerabilities == 'true'
     shell: bash
     env:
-      # Passed via env rather than expanded into the script: caller-controlled
-      # input, expanding it inline is shell injection (zizmor: template-injection).
+      # Passed via env (zizmor: template-injection).
       SCAN_SEVERITY: ${{ inputs.scan_severity }}
     run: |
       trivy convert --scanners vuln,secret --format sarif \
@@ -116,14 +112,12 @@ runs:
     with:
       sarif_file: 'trivy-results.sarif'
 
-  # Names must be unique per run, and github.job is not: buildPublic and buildGCP both reach
-  # this action through a reusable workflow whose job is `buildImage`. The scan target splits them.
+  # Enforce unique names, otherwise buildPublic and buildGCP would conflict
   - name: Name the report artifacts
     id: reportName
     shell: bash
     env:
-      # Passed via env rather than expanded into the script: caller-controlled
-      # inputs, expanding them inline is shell injection (zizmor: template-injection).
+      # Passed via env (zizmor: template-injection).
       IMAGE_REF: ${{ inputs.image_ref }}
       SCAN_TYPE: ${{ inputs.scan_type }}
       JOB: ${{ github.job }}
@@ -131,9 +125,9 @@ runs:
       target="${IMAGE_REF:-$SCAN_TYPE}"
       target="${target//[^A-Za-z0-9._-]/-}"      # artifact names reject :/\<>|*?"
       echo "value=trivy-report-${JOB}-${target}" >> "$GITHUB_OUTPUT"
-      echo "gate=trivy-gate-${JOB}-${target}" >> "$GITHUB_OUTPUT"
+      echo "fail_only=trivy-fail-only-${JOB}-${target}" >> "$GITHUB_OUTPUT"
 
-  # Machine-readable copy, so triage tooling need not parse the table out of the job log.
+  # Upload the JSON report to be used by triage tooling
   - name: Upload Trivy JSON report
     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
@@ -142,36 +136,34 @@ runs:
       retention-days: 30
       overwrite: true
 
-  # Only what fails the build, without the package inventory. failure_severity is applied here
-  # because it is not recorded in the report, so a consumer cannot re-derive it.
-  - name: Render gate-scoped JSON report
+  # Create the fail-only JSON report to be used by triage tooling
+  # Only includes the vulnerabilities matching FAILURE_SEVERITY
+  - name: Render fail-only JSON report
     shell: bash
     env:
-      # See note on SCAN_SEVERITY above.
       FAILURE_SEVERITY: ${{ inputs.failure_severity }}
     run: |
       trivy convert --scanners vuln,secret --format json --severity "${FAILURE_SEVERITY}" \
-        --list-all-pkgs=false --output trivy-gate.json trivy-results.json
+        --list-all-pkgs=false --output trivy-fail-only.json trivy-results.json
 
-  - name: Upload gate-scoped JSON report
+  - name: Upload fail-only JSON report
     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
-      name: ${{ steps.reportName.outputs.gate }}
-      path: trivy-gate.json
+      name: ${{ steps.reportName.outputs.fail_only }}
+      path: trivy-fail-only.json
       retention-days: 30
       overwrite: true
 
-  - name: Local vulnerability scanner for MEDIUM,HIGH,CRITICAL for reporting
+  - name: Output table with all MEDIUM,HIGH,CRITICAL vulns (if full_report)
     if: ${{ inputs.full_report  == 'true' }}
     shell: bash
     run: |
       trivy convert --scanners vuln,secret --format table --dependency-tree \
         --severity 'MEDIUM,HIGH,CRITICAL' trivy-results.json
 
-  - name: Test with Trivy vulnerability scanner
+  - name: Fail if vulns matching security threshold found
     shell: bash
     env:
-      # See note on SCAN_SEVERITY above.
       FAILURE_SEVERITY: ${{ inputs.failure_severity }}
     run: |
       trivy convert --scanners vuln,secret --format table \


### PR DESCRIPTION
Trivy results are currently only available as tables in the job log, which is fragile to parse — titles truncate mid-string (sometimes swallowing another CVE id), multi-version findings render as one merged row, and column offsets shift under `gh`'s log prefixes.

`trivy convert` re-renders a JSON report into any other format without rescanning, so we can emit JSON without giving up the table.

## What changed

**`actions/vulnerability_scan`**

- Scan once to JSON at all severities; render the SARIF, full report and failure gate from it via `trivy convert`
- Upload two artifacts:
  - `trivy-report-<job>-<target>` — the full report, with the package inventory
  - `trivy-fail-only-<job>-<target>` — only what fails the build (`failure_severity`, no package list, ~10KB). The gating floor isn't recorded in the report, so a consumer can't re-derive it.

Names encode job + scan target because `github.job` alone collides: in `Publish All Operators`, `buildPublic` and `buildGCP` both reach this action through a reusable workflow whose job is `buildImage`.

**`shared-vulnerability-scan-failure-notify.yaml`**

- Derive the built image tag from the Dockerfile instead of the sha alone. A caller can matrix over Dockerfiles (ssp does), but every leg shared `github.job` *and* `github.sha`, so `image_ref` was identical across legs and the new artifact names would have collided — silently, given `overwrite: true`. `image_ref` now references the derived tag rather than rebuilding it.

## Behaviour is unchanged

Verified A/B against `eclipse-temurin@sha256:3f08b1…` with `uid2-operator`'s `.trivyignore` active:

| Output | Result |
|---|---|
| Gate table + exit code | byte-identical |
| Full report table | identical (one extra `--dependency-tree` INFO line) |
| SARIF | rules and results identical |
| `.trivyignore` suppression | still applied |

Dependency-tree detail survives the JSON round-trip: verified separately on an npm tree (684 packages, 392 with `DependsOn`), where the converted full report is identical to the old dedicated scan.

The scan runs at all severities because `convert` only filters down, and does so silently — converting to MEDIUM from a `CRITICAL,HIGH` report prints `MEDIUM: 0` rather than erroring. Scanning at the widest floor makes the report a superset by construction. Severity is a report-side filter, so scan time is unaffected (+2.7% report size on a repo carrying LOWs).

Both uploads are ordered before the gate step so they still publish when the scan fails.

## Verification

Ran end-to-end from this branch ([run 31350652174](https://github.com/IABTechLab/uid2-shared-actions/actions/runs/31350652174), temporary pins since reverted): both artifacts produced, valid JSON, `trivy-report` carrying 6 MEDIUM + 12 packages and `trivy-fail-only` correctly empty at `CRITICAL,HIGH`.

## Rollout

Callers pin `@v3`, so nothing changes until the tag is moved. Out of scope: `uid2-operator`'s `publish-azure-cc-enclave-docker.yaml` and `uid2-snowflake`'s `build_scan_push` keep their own inline `trivy-action` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)